### PR TITLE
Add Lava Chicken music disc item entry

### DIFF
--- a/scripts/data/providers/items/misc/music_discs.js
+++ b/scripts/data/providers/items/misc/music_discs.js
@@ -237,5 +237,29 @@ export const musicDiscs = {
             "Rarity: Uncommon"
         ],
         description: "'Tears' is a music disc composed by Amos Roddy and released as part of the 'Chase the Skies' soundtrack. It is obtained when a Ghast is defeated by a player-deflected fireball. When played in a jukebox, the track, an electronic piece incorporating ghast vocal samples, plays for approximately 2:55 and a comparator next to the jukebox emits a signal of 10."
+    },
+    "minecraft:music_disc_lava_chicken": {
+        id: "minecraft:music_disc_lava_chicken",
+        name: "Music Disc (Lava Chicken)",
+        maxStack: 1,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Playing the 'Lava Chicken' music track in a Jukebox",
+            secondaryUse: "Providing a redstone signal strength of 9 via a Comparator"
+        },
+        crafting: {
+            recipeType: "Uncraftable",
+            ingredients: ["Dropped by chicken jockeys (baby zombie riding a chicken)"]
+        },
+        specialNotes: [
+            "Composed by Hyper Potions",
+            "Added in Java 1.21.7 and Bedrock 1.21.93",
+            "Dropped by chicken jockeys (baby zombie riding a chicken)",
+            "Emits a comparator signal strength of 9 when played in a Jukebox",
+            "Track length: 2:15",
+            "Inspired by 'Steve\'s Lava Chicken' from A Minecraft Movie"
+        ],
+        description: "'Lava Chicken' is a music disc that plays Hyper Potions' 'Lava Chicken' track (approx. 2:15). It is obtained by defeating chicken jockeys (baby zombies riding chickens). When played in a jukebox, it provides a comparator signal strength of 9."
     }
 };

--- a/scripts/data/search/item_index.js
+++ b/scripts/data/search/item_index.js
@@ -1183,6 +1183,13 @@ export const itemIndex = [
         themeColor: "§b" // aqua
     },
     {
+        id: "minecraft:music_disc_lava_chicken",
+        name: "Music Disc (Lava Chicken)",
+        category: "item",
+        icon: "textures/items/music_disc_lava_chicken",
+        themeColor: "§c" // red
+    },
+    {
         id: "minecraft:tide_armor_trim_smithing_template",
         name: "Tide Armor Trim Smithing Template",
         category: "item",


### PR DESCRIPTION
## Summary
Adds the "Lava Chicken" music disc item entry for Minecraft (Bedrock). This PR includes both a search index entry (`scripts/data/search/item_index.js`) and a detailed provider entry (`scripts/data/providers/items/misc/music_discs.js`).

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [x] Item

## Verification
- [x] I have verified the information is accurate (Minecraft Wiki and official release notes)
- [x] IDs match official Minecraft Bedrock Edition IDs (identifier: `music_disc_lava_chicken`)
