### PR TITLE
feat: Add Netherite Leggings and Boots item entries

### DIFF
--- a/scripts/data/providers/items/armor/boots.js
+++ b/scripts/data/providers/items/armor/boots.js
@@ -31,5 +31,29 @@ export const boots = {
             "Repaired using Iron Ingots in an Anvil"
         ],
         description: "Chainmail Boots are a type of armor that offers the same protection as Gold Boots but with significantly higher durability, matching Iron. They are unique as they cannot be crafted and are only obtained through trading with Armorer villagers, finding them in Buried Treasure, or as rare drops from mobs. They provide moderate protection for the feet and have a distinctive mesh appearance."
+    },
+    "minecraft:netherite_boots": {
+        id: "minecraft:netherite_boots",
+        name: "Netherite Boots",
+        maxStack: 1,
+        durability: 481,
+        enchantable: true,
+        usage: {
+            primaryUse: "Superior foot protection",
+            secondaryUse: "Fire resistance and knockback protection"
+        },
+        crafting: {
+            recipeType: "Smithing",
+            ingredients: ["Diamond Boots", "Netherite Ingot", "Netherite Upgrade Smithing Template"]
+        },
+        specialNotes: [
+            "Provides 3 armor points (same as Diamond)",
+            "Durability: 481 (Diamond has 429 in Bedrock)",
+            "Grants 10% knockback resistance",
+            "Item is immune to fire and lava damage",
+            "Requires Smithing Table and Upgrade Template to craft",
+            "Highest tier of foot protection in the game"
+        ],
+        description: "Netherite Boots are the ultimate foot protection in Minecraft Bedrock Edition. Providing 3 points of armor, they match Diamond Boots in defensive value but possess significantly higher durability and built-in knockback resistance. Like all netherite gear, these boots are immune to fire and lava, floating safely if dropped into heat. They must be crafted by upgrading Diamond Boots using a Netherite Ingot and a Netherite Upgrade Smithing Template at a Smithing Table."
     }
 };

--- a/scripts/data/providers/items/armor/leggings.js
+++ b/scripts/data/providers/items/armor/leggings.js
@@ -33,5 +33,29 @@ export const leggings = {
             "Partially transparent texture"
         ],
         description: "Chainmail Leggings provide 4 armor points of protection for the legs, one point less than Iron Leggings, while maintaining the same durability of 225. They possess a higher enchantability rating (12), allowing for potentially better enchantment rolls. Uncraftable in survival, they are primarily sourced from Armorer villagers, loot chests, or drops from armored mobs. Like other chainmail pieces, they can be repaired using Iron Ingots in an anvil."
+    },
+    "minecraft:netherite_leggings": {
+        id: "minecraft:netherite_leggings",
+        name: "Netherite Leggings",
+        maxStack: 1,
+        durability: 555,
+        enchantable: true,
+        usage: {
+            primaryUse: "Superior leg protection",
+            secondaryUse: "Fire resistance and knockback protection"
+        },
+        crafting: {
+            recipeType: "Smithing",
+            ingredients: ["Diamond Leggings", "Netherite Ingot", "Netherite Upgrade Smithing Template"]
+        },
+        specialNotes: [
+            "Provides 6 armor points (same as Diamond)",
+            "Durability: 555 (Diamond has 495 in Bedrock)",
+            "Grants 10% knockback resistance",
+            "Item is immune to fire and lava damage",
+            "Requires Smithing Table and Upgrade Template to craft",
+            "Highest tier of leg protection in the game"
+        ],
+        description: "Netherite Leggings are the strongest and most durable leg armor in Minecraft Bedrock Edition. They provide the same 6 points of armor as Diamond Leggings but offer significantly higher durability and built-in knockback resistance. A unique property of netherite equipment is its immunity to fire and lava; if dropped, the item will float on top of lava rather than burning. They are crafted by upgrading Diamond Leggings with a Netherite Ingot and a Smithing Template at a Smithing Table."
     }
 };

--- a/scripts/data/search/item_index.js
+++ b/scripts/data/search/item_index.js
@@ -2209,6 +2209,19 @@ export const itemIndex = [
         name: "Jungle Boat",
         category: "item",
         icon: "textures/items/boat_jungle",
-        themeColor: "§6" // gold/wood
+    },
+    {
+        id: "minecraft:netherite_leggings",
+        name: "Netherite Leggings",
+        category: "item",
+        icon: "textures/items/netherite_leggings",
+        themeColor: "§8" // dark gray/netherite
+    },
+    {
+        id: "minecraft:netherite_boots",
+        name: "Netherite Boots",
+        category: "item",
+        icon: "textures/items/netherite_boots",
+        themeColor: "§8" // dark gray/netherite
     }
 ];


### PR DESCRIPTION
## Description
This PR adds two missing high-tier armor entries for Minecraft Bedrock: **Netherite Leggings** and **Netherite Boots**. These entries provide detailed statistics including Bedrock-specific durability, armor points, knockback resistance, and fire immunity.

### Changes
- Added search index entries for `minecraft:netherite_leggings` and `minecraft:netherite_boots` in `scripts/data/search/item_index.js`.
- Added detailed provider data for `minecraft:netherite_leggings` in `scripts/data/providers/items/armor/leggings.js`.
- Added detailed provider data for `minecraft:netherite_boots` in `scripts/data/providers/items/armor/boots.js`.

### Verification
- Verified Bedrock-specific durability (555 for leggings, 481 for boots) against Minecraft Wiki.
- Ensured all required fields (`id`, `name`, `maxStack`, `durability`, `enchantable`, `usage`, `crafting`, `specialNotes`, `description`) are present.
- Confirmed descriptions and special notes are within character and count limits.
