### PR TITLE
Add Nether Quartz Ore and Mangrove Leaves block entries

### DIFF
--- a/scripts/data/providers/blocks/natural/ores.js
+++ b/scripts/data/providers/blocks/natural/ores.js
@@ -199,5 +199,26 @@ export const oreBlocks = {
             yRange: "-64 to 15 (deepslate layers)"
         },
         description: "Deepslate Diamond Ore is a variant of diamond ore that generates in deepslate and tuff layers, found more commonly than regular diamond ore due to its lower altitude generation. It requires an iron pickaxe or better to mine. Like regular diamond ore, it drops diamonds when mined without Silk Touch, with increased yields from Fortune enchantment. Deepslate diamond ore also generates as part of fossils that generate below Y=0, replacing some bone blocks."
+    },
+    "minecraft:quartz_ore": {
+        id: "minecraft:quartz_ore",
+        name: "Nether Quartz Ore",
+        hardness: 3.0,
+        blastResistance: 3.0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: true
+        },
+        drops: ["Nether Quartz (1, affected by Fortune)"],
+        generation: {
+            dimension: "Nether",
+            yRange: "7 to 117"
+        },
+        description: "Nether Quartz Ore is a common ore found exclusively in the Nether. It is easily identifiable by its white streaks against the red netherrack. When mined with a pickaxe, it drops one Nether Quartz and experience orbs. It is an essential resource for crafting redstone components like comparators and observers, as well as decorative quartz blocks. In Bedrock Edition, it is one of the primary reasons players venture into the Nether early on, providing a quick source of experience and materials for automation."
     }
 };

--- a/scripts/data/providers/blocks/natural/wood.js
+++ b/scripts/data/providers/blocks/natural/wood.js
@@ -241,5 +241,26 @@ export const woodBlocks = {
             yRange: "Crafted from Crimson Stem"
         },
         description: "Crimson Hyphae is a block with the bark texture of Crimson Stem on all six sides. It can be crafted by arranging four Crimson Stems in a 2x2 grid. It is often used in building for creating custom trees or organic structures where the log rings are not desired. Like the stem, it is fire-resistant and can be stripped to create Stripped Crimson Hyphae."
+    },
+    "minecraft:mangrove_leaves": {
+        id: "minecraft:mangrove_leaves",
+        name: "Mangrove Leaves",
+        hardness: 0.2,
+        blastResistance: 0.2,
+        flammability: true,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Shears",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Mangrove Propagule", "Stick", "Mangrove Leaves (with Shears)"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Mangrove Swamps"
+        },
+        description: "Mangrove Leaves are the dense, dark green foliage of Mangrove trees found in swampy biomes. Unique among leaf blocks, they can host Mangrove Propagules, which hang from the underside as they grow. While they can be broken with any tool, shears or hoes are the most efficient. To obtain the leaf block itself, shears must be used. In Bedrock Edition, these leaves contribute to the thick, atmospheric canopy of Mangrove Swamps, often generating with vines and moss, making the biome challenging to navigate but rich in wood resources."
     }
 };

--- a/scripts/data/search/block_index.js
+++ b/scripts/data/search/block_index.js
@@ -2140,5 +2140,19 @@ export const blockIndex = [
         category: "block",
         icon: "textures/blocks/wooden_button",
         themeColor: "§6"
+    },
+    {
+        id: "minecraft:quartz_ore",
+        name: "Nether Quartz Ore",
+        category: "block",
+        icon: "textures/blocks/quartz_ore",
+        themeColor: "§f"
+    },
+    {
+        id: "minecraft:mangrove_leaves",
+        name: "Mangrove Leaves",
+        category: "block",
+        icon: "textures/blocks/mangrove_leaves",
+        themeColor: "§2"
     }
 ];


### PR DESCRIPTION
## Summary
Added new block entries for Nether Quartz Ore and Mangrove Leaves, including search index and detailed provider data.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [ ] Mob
- [x] Block
- [ ] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs