### PR TITLE
Add Bedrock and Wither Rose block entries

### DIFF
--- a/scripts/data/providers/blocks/natural/stone.js
+++ b/scripts/data/providers/blocks/natural/stone.js
@@ -451,5 +451,26 @@ export const stoneBlocks = {
             yRange: "Deepslate layers (below Y 0)"
         },
         description: "Cobbled Deepslate is a rough stone variant obtained by mining Deepslate with a pickaxe. It shares the dark gray aesthetic of Deepslate but with a fractured texture. With a hardness of 3.5 and blast resistance of 6.0, it is tougher than regular cobblestone. It is used to craft stone tools, furnaces, and brewing stands, and can be smelted back into Deepslate or crafted into Polished Deepslate."
+    },
+    "minecraft:bedrock": {
+        id: "minecraft:bedrock",
+        name: "Bedrock",
+        hardness: -1.0,
+        blastResistance: 3600000.0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: [],
+        generation: {
+            dimension: "Overworld, Nether, End",
+            yRange: "-64 to -60 (Overworld), 0-4 & 123-127 (Nether)"
+        },
+        description: "Bedrock is an indestructible block that forms the boundary of the world. It generates at the very bottom of the Overworld and both the top and bottom of the Nether, preventing players from falling into the void or escaping the dimension's confines. While it can be viewed and used as a foundation in Creative mode, it is impossible to mine or destroy in Survival mode without using glitches. It also serves as the primary component of the End's exit portal and gateway structures, providing a permanent frame for these essential inter-dimensional travel points."
     }
 };

--- a/scripts/data/providers/blocks/natural/vegetation.js
+++ b/scripts/data/providers/blocks/natural/vegetation.js
@@ -687,5 +687,26 @@ export const vegetationBlocks = {
             yRange: "Deserts, Badlands, Giant Tree Taigas"
         },
         description: "Dead Bush is a decorative transparent block found in arid biomes such as Deserts, Badlands, and Giant Tree Taigas. It represents a withered shrub and provides an atmospheric touch to dry environments. When broken by hand or with most tools, it has a chance to drop 0-2 Sticks, serving as an emergency source of wood in treeless areas. To collect the Dead Bush itself for decoration (e.g., in flower pots), players must use Shears."
+    },
+    "minecraft:wither_rose": {
+        id: "minecraft:wither_rose",
+        name: "Wither Rose",
+        hardness: 0.0,
+        blastResistance: 0.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Wither Rose"],
+        generation: {
+            dimension: "Overworld, Nether, End",
+            yRange: "N/A (Spawns when Wither kills a mob)"
+        },
+        description: "The Wither Rose is a rare, dark flower that is created when a Wither kills a non-undead mob. Unlike most plants, it inflicts the Wither effect on any creature that walks through it, making it a powerful tool for traps and automated mob farms. It can be placed on most solid blocks, including netherrack and soul sand, which is atypical for flowers. Despite its lethal nature, it can be used to craft Black Dye or as a decorative element in more macabre builds. It is one of the few flowers that can be found in any dimension, provided a Wither has been summoned to create it."
     }
 };

--- a/scripts/data/search/block_index.js
+++ b/scripts/data/search/block_index.js
@@ -42,6 +42,13 @@ export const blockIndex = [
         themeColor: "§7" // gray
     },
     {
+        id: "minecraft:bedrock",
+        name: "Bedrock",
+        category: "block",
+        icon: "textures/blocks/bedrock",
+        themeColor: "§8" // dark gray
+    },
+    {
         id: "minecraft:dripstone_block",
         name: "Dripstone Block",
         category: "block",
@@ -2028,6 +2035,13 @@ export const blockIndex = [
         category: "block",
         icon: "textures/blocks/cactus_side",
         themeColor: "§2" // dark green
+    },
+    {
+        id: "minecraft:wither_rose",
+        name: "Wither Rose",
+        category: "block",
+        icon: "textures/blocks/wither_rose",
+        themeColor: "§0" // black
     },
     {
         id: "minecraft:deadbush",


### PR DESCRIPTION
## Summary
Added detailed block entries for Bedrock and Wither Rose, including search index entries and provider data for Minecraft Bedrock Edition.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [ ] Mob
- [x] Block
- [ ] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs