### PR TITLE
Add multiple block entries: Oak, Spruce, Birch, Jungle, Acacia, Dark Oak logs, Glass Pane, Iron Door, Cobblestone Wall, and Mossy Cobblestone Wall

### DIFF
--- a/scripts/data/providers/blocks/building/glass.js
+++ b/scripts/data/providers/blocks/building/glass.js
@@ -50,5 +50,26 @@ export const glassBlocks = {
             yRange: "Crafted from Sand x4 in Furnace, Ocean Monuments (glass panes)"
         },
         description: "Glass is a fundamental transparent building block crafted by smelting sand in a furnace. It serves as a versatile construction material that allows light to pass through while providing weather protection. Glass is essential for building greenhouses, windows, modern architecture, and underwater structures. While fragile with low hardness and blast resistance (0.3 each), glass can be crafted into glass panes for more efficient space usage and lighter visual weight. Glass blocks are non-flammable and provide complete visibility from both sides. They're perfect for creating bright, airy interiors and are especially valuable for farming setups, aquariums, and decorative lighting effects. In Bedrock Edition, glass drops itself when broken, making collection straightforward without the need for Silk Touch enchantment."
+    },
+    "minecraft:glass_pane": {
+        id: "minecraft:glass_pane",
+        name: "Glass Pane",
+        hardness: 0.3,
+        blastResistance: 0.3,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: true
+        },
+        drops: ["Glass Pane (with Silk Touch)"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Crafted from 6 Glass blocks"
+        },
+        description: "Glass Panes are thin, transparent blocks used primarily for windows and decorative elements. They are crafted from six glass blocks, yielding sixteen panes, making them much more material-efficient than full blocks. Panes connect to adjacent blocks and other panes, creating a seamless glass surface. While they offer the same visibility and light transmission as glass blocks, they take up only a fraction of a block's width, allowing for more detailed and space-efficient architectural designs."
     }
 };

--- a/scripts/data/providers/blocks/building/slabs_stairs.js
+++ b/scripts/data/providers/blocks/building/slabs_stairs.js
@@ -218,5 +218,47 @@ export const slabsStairsBlocks = {
             yRange: "Crafted from Resin Bricks"
         },
         description: "Resin Brick Slab is a half-block variant of Resin Bricks, introduced in Minecraft 1.21.50. It allows for more precise building and decoration with the distinctive warm, orange-toned brick texture of resin. Crafted from three Resin Bricks in a row or using a stonecutter, it is perfect for flooring, steps, and roofing. Like other resin brick blocks, it is durable and blast-resistant, serving as a key component in the resin block family."
+    },
+    "minecraft:cobblestone_wall": {
+        id: "minecraft:cobblestone_wall",
+        name: "Cobblestone Wall",
+        hardness: 2.0,
+        blastResistance: 6.0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["Cobblestone Wall"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Villages"
+        },
+        description: "Cobblestone Walls are decorative barrier blocks crafted from cobblestone. They act as a medium-height fence that players and most mobs cannot jump over, making them excellent for perimeter defense and animal pens. Walls automatically connect to adjacent solid blocks and other walls, forming a continuous barrier. They offer a rugged, stony aesthetic perfect for castles, dungeons, and rustic villages. Unlike fences, they are non-flammable and provide higher blast resistance."
+    },
+    "minecraft:mossy_cobblestone_wall": {
+        id: "minecraft:mossy_cobblestone_wall",
+        name: "Mossy Cobblestone Wall",
+        hardness: 2.0,
+        blastResistance: 6.0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["Mossy Cobblestone Wall"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Jungle Temples, Villages"
+        },
+        description: "Mossy Cobblestone Walls are a variant of cobblestone walls that feature moss-covered stone. They provide the same functional benefits as regular walls, acting as a jump-proof barrier that connects to nearby blocks. The overgrown, aged appearance makes them ideal for ruins, jungle-themed builds, and overgrown gardens. They are crafted from mossy cobblestone or by combining regular cobblestone walls with vines or moss blocks, adding a touch of history and nature to any construction."
     }
 };

--- a/scripts/data/providers/blocks/functional/interactive.js
+++ b/scripts/data/providers/blocks/functional/interactive.js
@@ -536,5 +536,26 @@ export const interactiveBlocks = {
             yRange: "Command only"
         },
         description: "The Structure Void is an invisible, intangible block used to indicate empty space in structures saved with Structure Blocks. When a structure is loaded, blocks in the target area are not overwritten if the corresponding block in the saved structure is a structure void. It is distinct from air, which overwrites existing blocks with air. Visible only when holding a structure void item or enabling 'Show Invisible Blocks', it allows for complex structure merging and terrain preservation."
+    },
+    "minecraft:iron_door": {
+        id: "minecraft:iron_door",
+        name: "Iron Door",
+        hardness: 5.0,
+        blastResistance: 5.0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["Iron Door"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Strongholds, Shipwrecks"
+        },
+        description: "Iron Doors are heavy-duty versions of standard wooden doors, providing significantly more security. Unlike wooden doors, iron doors cannot be opened by hand; they require a redstone signal, such as a lever, button, or pressure plate, to operate. This makes them ideal for protecting bases from mobs and unwanted players. In Bedrock Edition, they can be mined with any pickaxe. Their high blast resistance and security features make them a staple in high-tech and defensive builds."
     }
 };

--- a/scripts/data/providers/blocks/natural/wood.js
+++ b/scripts/data/providers/blocks/natural/wood.js
@@ -32,6 +32,132 @@ export const woodBlocks = {
         },
         description: "Pale Oak Log is a wood type unique to the Pale Garden biome, introduced in Minecraft Bedrock Edition 1.21.50. These pale, grayish-brown logs form the trunks of Pale Oak trees, creating an eerie atmosphere with their muted coloration. Like other logs, they can be stripped with an axe and crafted into pale oak planks, stripped pale oak logs, or pale oak wood. The distinctive appearance of pale oak makes it popular for atmospheric builds, especially those seeking a ghostly or mystical aesthetic."
     },
+    "minecraft:oak_log": {
+        id: "minecraft:oak_log",
+        name: "Oak Log",
+        hardness: 2.0,
+        blastResistance: 2.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Oak Log"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "0 to 320"
+        },
+        description: "Oak logs are basic wood blocks obtained from oak trees, the most common tree in Minecraft. They feature a brownish bark and a light tan interior. Oak logs are versatile building materials and can be crafted into oak planks, charcoal, or stripped using an axe. They are essential for early-game survival, providing the primary source of wood for tools and construction in most Overworld biomes."
+    },
+    "minecraft:spruce_log": {
+        id: "minecraft:spruce_log",
+        name: "Spruce Log",
+        hardness: 2.0,
+        blastResistance: 2.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Spruce Log"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "0 to 320"
+        },
+        description: "Spruce logs are harvested from spruce trees found in taiga and snowy biomes. They have a dark brown, rugged bark and a slightly lighter interior. Spruce logs are favored by builders for their rustic and cozy aesthetic. Like other logs, they can be crafted into planks, stripped, or used as fuel. They are particularly common in cold climates and provide a sturdy look to cabins and medieval-style builds."
+    },
+    "minecraft:birch_log": {
+        id: "minecraft:birch_log",
+        name: "Birch Log",
+        hardness: 2.0,
+        blastResistance: 2.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Birch Log"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "0 to 320"
+        },
+        description: "Birch logs come from birch trees, easily identified by their distinctive white bark with dark spots. The interior wood is light-colored, making it popular for bright and modern architectural designs. Birch logs can be processed into planks, stripped for a clean look, or used for crafting and fuel. They are found in birch forests and occasionally in other biomes, offering a stark contrast to typical darker wood types."
+    },
+    "minecraft:jungle_log": {
+        id: "minecraft:jungle_log",
+        name: "Jungle Log",
+        hardness: 2.0,
+        blastResistance: 2.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Jungle Log"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "0 to 320"
+        },
+        description: "Jungle logs are found in lush jungle biomes, forming the massive trunks of jungle trees. They have a greenish-brown bark and a warm, brownish-red interior. Jungle logs are essential for building in tropical environments and can be crafted into jungle-themed planks or stripped logs. They are also needed to grow cocoa beans, which can be placed on the sides of the logs to mature."
+    },
+    "minecraft:acacia_log": {
+        id: "minecraft:acacia_log",
+        name: "Acacia Log",
+        hardness: 2.0,
+        blastResistance: 2.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Acacia Log"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "0 to 320"
+        },
+        description: "Acacia logs are unique to savanna biomes, harvested from the twisted acacia trees. They feature a gray bark and a vibrant orange interior wood. This striking color contrast makes acacia a popular choice for colorful and modern builds. Acacia logs can be crafted into planks, stripped, or used for various wooden components. Their natural resistance to the savanna environment is reflected in their rugged appearance."
+    },
+    "minecraft:dark_oak_log": {
+        id: "minecraft:dark_oak_log",
+        name: "Dark Oak Log",
+        hardness: 2.0,
+        blastResistance: 2.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Dark Oak Log"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "0 to 320"
+        },
+        description: "Dark oak logs are obtained from the thick-trunked dark oak trees found in dark forest biomes. They feature a very dark brown bark and a rich, deep brown interior wood. Due to their dark coloration, they are often used for sophisticated and imposing structures. Dark oak logs can be processed into dark oak planks, stripped, or used as fuel. They are also known for being required to grow large 2x2 dark oak trees."
+    },
     "minecraft:pale_oak_leaves": {
         id: "minecraft:pale_oak_leaves",
         name: "Pale Oak Leaves",

--- a/scripts/data/search/block_index.js
+++ b/scripts/data/search/block_index.js
@@ -476,6 +476,76 @@ export const blockIndex = [
         themeColor: "§e" // pale yellow
     },
     {
+        id: "minecraft:oak_log",
+        name: "Oak Log",
+        category: "block",
+        icon: "textures/blocks/log_oak",
+        themeColor: "§6"
+    },
+    {
+        id: "minecraft:spruce_log",
+        name: "Spruce Log",
+        category: "block",
+        icon: "textures/blocks/log_spruce",
+        themeColor: "§6"
+    },
+    {
+        id: "minecraft:birch_log",
+        name: "Birch Log",
+        category: "block",
+        icon: "textures/blocks/log_birch",
+        themeColor: "§f"
+    },
+    {
+        id: "minecraft:jungle_log",
+        name: "Jungle Log",
+        category: "block",
+        icon: "textures/blocks/log_jungle",
+        themeColor: "§6"
+    },
+    {
+        id: "minecraft:acacia_log",
+        name: "Acacia Log",
+        category: "block",
+        icon: "textures/blocks/log_acacia",
+        themeColor: "§7"
+    },
+    {
+        id: "minecraft:dark_oak_log",
+        name: "Dark Oak Log",
+        category: "block",
+        icon: "textures/blocks/log_big_oak",
+        themeColor: "§8"
+    },
+    {
+        id: "minecraft:glass_pane",
+        name: "Glass Pane",
+        category: "block",
+        icon: "textures/items/glass_pane",
+        themeColor: "§f"
+    },
+    {
+        id: "minecraft:iron_door",
+        name: "Iron Door",
+        category: "block",
+        icon: "textures/items/door_iron",
+        themeColor: "§7"
+    },
+    {
+        id: "minecraft:cobblestone_wall",
+        name: "Cobblestone Wall",
+        category: "block",
+        icon: "textures/blocks/cobblestone_wall",
+        themeColor: "§7"
+    },
+    {
+        id: "minecraft:mossy_cobblestone_wall",
+        name: "Mossy Cobblestone Wall",
+        category: "block",
+        icon: "textures/blocks/mossy_cobblestone_wall",
+        themeColor: "§2"
+    },
+    {
         id: "minecraft:pale_oak_leaves",
         name: "Pale Oak Leaves",
         category: "block",


### PR DESCRIPTION
## Summary
Adding 10 essential base blocks for Minecraft Bedrock Edition, including various log types, glass panes, iron doors, and walls. These entries provide accurate data for hardness, blast resistance, and generation.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [ ] Mob
- [x] Block
- [ ] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs