### PR TITLE
Add multiple block entries: Cracked Deepslate variants, Quartz Pillar, and Bamboo set

### DIFF
--- a/scripts/data/providers/blocks/building/bricks.js
+++ b/scripts/data/providers/blocks/building/bricks.js
@@ -598,5 +598,47 @@ export const brickBlocks = {
             yRange: null
         },
         description: "Cracked Stone Bricks are a weathered version of stone bricks that feature visible cracks across their surface. They are created by smelting regular stone bricks in a furnace or found naturally in strongholds, igloo basements, ocean ruins (cold), ruined portals, and trail ruins. These blocks are excellent for depicting ruins, aged dungeons, or structural instability in builds. Despite their damaged look, they maintain a hardness of 1.5 and blast resistance of 6.0, the same as standard stone bricks. Silverfish can also hide inside infested versions of this block, which can be found in strongholds near the end portal."
+    },
+    "minecraft:cracked_deepslate_bricks": {
+        id: "minecraft:cracked_deepslate_bricks",
+        name: "Cracked Deepslate Bricks",
+        hardness: 3.5,
+        blastResistance: 6.0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["Cracked Deepslate Bricks"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Ancient Cities"
+        },
+        description: "Cracked Deepslate Bricks are a weathered variant of deepslate bricks, featuring visible fractures that suggest age and decay. They generate naturally within the dark, expansive structures of Ancient Cities in the Deep Dark biome. Players can also obtain them by smelting regular deepslate bricks in a furnace. These blocks are ideal for creating ruins, aged dungeons, or adding mechanical detail to dark-themed constructions. Despite their damaged appearance, they retain the high durability and blast resistance characteristic of the deepslate family, requiring a pickaxe to mine."
+    },
+    "minecraft:cracked_deepslate_tiles": {
+        id: "minecraft:cracked_deepslate_tiles",
+        name: "Cracked Deepslate Tiles",
+        hardness: 3.5,
+        blastResistance: 6.0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["Cracked Deepslate Tiles"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Ancient Cities"
+        },
+        description: "Cracked Deepslate Tiles are a decorative variant of deepslate tiles with a fractured surface. Found naturally in Ancient Cities, they add a sense of history and weathered texture to flooring and walls. They are produced by smelting standard deepslate tiles in a furnace. Like other deepslate variants, they are significantly harder than stone, requiring more time to mine. Their dark gray, tiled pattern with visible cracks makes them excellent for atmospheric builds, ruined temples, or intricate industrial designs where a worn, heavy aesthetic is desired."
     }
 };

--- a/scripts/data/providers/blocks/building/slabs_stairs.js
+++ b/scripts/data/providers/blocks/building/slabs_stairs.js
@@ -239,5 +239,47 @@ export const slabsStairsBlocks = {
             yRange: "Crafted from Mud Bricks"
         },
         description: "Mud Brick Stairs are the stair-shaped variant of mud bricks, introduced in 1.19's Wild Update. They offer a warm, earthy-brown aesthetic that is perfect for desert, swamp, or rustic-themed builds. Crafted from six mud bricks or via a stonecutter, they allow for smooth vertical transitions and detailed roofing. While they have relatively low blast resistance compared to stone stairs, they provide a unique texture that bridges the gap between wood and stone. They can be waterlogged and placed in various orientations to create complex architectural details."
+    },
+    "minecraft:bamboo_stairs": {
+        id: "minecraft:bamboo_stairs",
+        name: "Bamboo Stairs",
+        hardness: 2.0,
+        blastResistance: 3.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Bamboo Stairs"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Crafted from Bamboo Planks"
+        },
+        description: "Bamboo Stairs are a building block crafted from bamboo planks, introduced in Minecraft 1.20 as part of the bamboo wood set. They feature a unique 'woven' texture distinct from traditional wood planks, offering a tropical or oriental aesthetic to structures. Like other stairs, they allow for smooth elevation changes and can be used for detailed roofing and trim. They are flammable and can be broken most efficiently with an axe. Bamboo stairs are also waterloggable, making them versatile for various architectural and landscape designs."
+    },
+    "minecraft:bamboo_slab": {
+        id: "minecraft:bamboo_slab",
+        name: "Bamboo Slab",
+        hardness: 2.0,
+        blastResistance: 3.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Bamboo Slab"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Crafted from Bamboo Planks"
+        },
+        description: "Bamboo Slab is a half-block variant of bamboo planks, featuring the same distinctive yellow-tan woven texture. It provides a low-profile building option for floors, ceilings, and intricate architectural details. Crafted by placing three bamboo planks horizontally or using a stonecutter, it is an essential part of the bamboo wood family. Bamboo slabs are flammable and can be combined into double slabs or placed in the top half of a block space. They offer a unique natural look that complements tropical, rustic, and modern builds effortlessly."
     }
 };

--- a/scripts/data/providers/blocks/dimension/nether.js
+++ b/scripts/data/providers/blocks/dimension/nether.js
@@ -598,5 +598,26 @@ export const netherBlocks = {
             dimension: "None"
         },
         description: "Cracked Nether Bricks are a decorative variant of nether bricks that appear aged and fractured. They are obtained by smelting regular nether bricks in a furnace. These blocks provide a weathered aesthetic to Nether fortresses and other dark-themed builds, suggesting long-term exposure to the Nether's intense heat. While they share the same resistance and hardness as regular nether bricks, they cannot be used to craft stairs or slabs. They are particularly effective when mixed with standard nether bricks to create textured, ruined walls and historical structures."
+    },
+    "minecraft:quartz_pillar": {
+        id: "minecraft:quartz_pillar",
+        name: "Quartz Pillar",
+        hardness: 0.8,
+        blastResistance: 0.8,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: true
+        },
+        drops: ["Quartz Pillar"],
+        generation: {
+            dimension: "Nether",
+            yRange: "Bastion Remnants, crafted from 2 Quartz Blocks"
+        },
+        description: "Quartz Pillar is a decorative variant of the quartz block, featuring a distinctive cylindrical texture with vertical lines. It is primarily used for constructing columns, pillars, and grand architectural features in classical or modern builds. It can be placed in different orientations, allowing the lines to run vertically or horizontally. Quartz pillars are crafted by vertically stacking two quartz blocks or obtained via a stonecutter. They generate naturally in bastion remnants and provide a clean, elegant aesthetic while maintaining the same properties as standard quartz blocks."
     }
 };

--- a/scripts/data/search/block_index.js
+++ b/scripts/data/search/block_index.js
@@ -2308,5 +2308,40 @@ export const blockIndex = [
         category: "block",
         icon: "textures/blocks/mud_brick_stairs",
         themeColor: "§6"
+    },
+    {
+        id: "minecraft:cracked_deepslate_bricks",
+        name: "Cracked Deepslate Bricks",
+        category: "block",
+        icon: "textures/blocks/deepslate_bricks_cracked",
+        themeColor: "§8"
+    },
+    {
+        id: "minecraft:cracked_deepslate_tiles",
+        name: "Cracked Deepslate Tiles",
+        category: "block",
+        icon: "textures/blocks/deepslate_tiles_cracked",
+        themeColor: "§8"
+    },
+    {
+        id: "minecraft:quartz_pillar",
+        name: "Quartz Pillar",
+        category: "block",
+        icon: "textures/blocks/quartz_pillar",
+        themeColor: "§f"
+    },
+    {
+        id: "minecraft:bamboo_stairs",
+        name: "Bamboo Stairs",
+        category: "block",
+        icon: "textures/blocks/bamboo_stairs",
+        themeColor: "§e"
+    },
+    {
+        id: "minecraft:bamboo_slab",
+        name: "Bamboo Slab",
+        category: "block",
+        icon: "textures/blocks/bamboo_slab",
+        themeColor: "§e"
     }
 ];


### PR DESCRIPTION
## Summary
Added 5 new block entries to provide more comprehensive coverage of Minecraft Bedrock Edition's building and dimension blocks. The new entries include cracked variants of deepslate, classical quartz pillars, and the versatile bamboo wood set.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [ ] Mob
- [x] Block
- [ ] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs

**Blocks added:**
1. Cracked Deepslate Bricks
2. Cracked Deepslate Tiles
3. Quartz Pillar
4. Bamboo Stairs
5. Bamboo Slab