### PR TITLE
Add multiple block entries: Weeping Vines, Crimson Fungus, Warped Fungus, Polished Basalt, Cherry Sapling

### DIFF
--- a/scripts/data/providers/blocks/dimension/nether.js
+++ b/scripts/data/providers/blocks/dimension/nether.js
@@ -3,7 +3,8 @@
 // This file contains: Netherrack, nether bricks, red nether bricks,
 // nether wart block, warped wart block, crimson nylium, warped nylium,
 // crimson stem, warped stem, shroomlight, basalt, smooth basalt,
-// polished basalt, blackstone variants, gilded blackstone,
+// polished basalt, weeping vines, crimson fungus, warped fungus,
+// blackstone variants, gilded blackstone,
 // soul sand, soul soil, magma block, glowstone, crying obsidian
 // ============================================
 
@@ -619,5 +620,89 @@ export const netherBlocks = {
             yRange: "Bastion Remnants, crafted from 2 Quartz Blocks"
         },
         description: "Quartz Pillar is a decorative variant of the quartz block, featuring a distinctive cylindrical texture with vertical lines. It is primarily used for constructing columns, pillars, and grand architectural features in classical or modern builds. It can be placed in different orientations, allowing the lines to run vertically or horizontally. Quartz pillars are crafted by vertically stacking two quartz blocks or obtained via a stonecutter. They generate naturally in bastion remnants and provide a clean, elegant aesthetic while maintaining the same properties as standard quartz blocks."
+    },
+    "minecraft:weeping_vines": {
+        id: "minecraft:weeping_vines",
+        name: "Weeping Vines",
+        hardness: 0,
+        blastResistance: 0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Shears",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Weeping Vines (with Shears)"],
+        generation: {
+            dimension: "Nether",
+            yRange: "Crimson Forest (ceiling)"
+        },
+        description: "Weeping Vines are red, climbable plants that grow downwards from the ceilings of Crimson Forests in the Nether. They can grow up to 26 blocks long and can be extended using bone meal. Unlike Overworld vines, they are non-flammable and grow from the top down. Players can climb them like ladders to navigate the vertical terrain of the Nether. To harvest them as an item, Shears must be used, although they can be broken instantly by any tool. They provide an atmospheric red aesthetic to the Crimson Forest biome."
+    },
+    "minecraft:crimson_fungus": {
+        id: "minecraft:crimson_fungus",
+        name: "Crimson Fungus",
+        hardness: 0,
+        blastResistance: 0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Crimson Fungus"],
+        generation: {
+            dimension: "Nether",
+            yRange: "Crimson Forest"
+        },
+        description: "Crimson Fungus is a mushroom-like block found naturally in the Crimson Forest biome of the Nether. It is primarily used to grow huge crimson fungi by using bone meal on it when placed on crimson nylium. This fungus is non-flammable and can be placed on various Nether surfaces including soul sand and soul soil. Hoglins are notably afraid of warped fungus, but they are not repelled by the crimson variant. It can also be used as an ingredient for suspicious stew or to breed Striders in Bedrock Edition."
+    },
+    "minecraft:warped_fungus": {
+        id: "minecraft:warped_fungus",
+        name: "Warped Fungus",
+        hardness: 0,
+        blastResistance: 0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Warped Fungus"],
+        generation: {
+            dimension: "Nether",
+            yRange: "Warped Forest"
+        },
+        description: "Warped Fungus is a teal-colored mushroom variant found in the Warped Forest biome. It is a vital resource in the Nether, used to breed and lead Striders, and can be combined with a fishing rod to create a Warped Fungus on a Stick. Notably, Hoglins are afraid of warped fungus and will stay at least 7 blocks away from it. When bone meal is used on a warped fungus placed on warped nylium, it grows into a huge warped fungus. Like its crimson counterpart, it is fire-resistant and serves as a decorative or functional botanical element."
+    },
+    "minecraft:polished_basalt": {
+        id: "minecraft:polished_basalt",
+        name: "Polished Basalt",
+        hardness: 1.25,
+        blastResistance: 4.25,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["Polished Basalt"],
+        generation: {
+            dimension: "Nether",
+            yRange: "Bastion Remnants, crafted from 4 Basalt"
+        },
+        description: "Polished Basalt is a decorative variant of basalt with a smooth finish and a cleaner texture. It is crafted from four regular basalt blocks in a 2x2 pattern or processed via a stonecutter. It generates naturally in some bastion remnant structures and provides a sophisticated dark gray aesthetic for building. Like logs, polished basalt is a directional block and can be placed in three different orientations. It maintains the same durability as raw basalt, requiring a pickaxe to mine efficiently and offering moderate resistance to explosions."
     }
 };

--- a/scripts/data/providers/blocks/natural/vegetation.js
+++ b/scripts/data/providers/blocks/natural/vegetation.js
@@ -708,5 +708,26 @@ export const vegetationBlocks = {
             yRange: "N/A (Spawns when Wither kills a mob)"
         },
         description: "The Wither Rose is a rare, dark flower that is created when a Wither kills a non-undead mob. Unlike most plants, it inflicts the Wither effect on any creature that walks through it, making it a powerful tool for traps and automated mob farms. It can be placed on most solid blocks, including netherrack and soul sand, which is atypical for flowers. Despite its lethal nature, it can be used to craft Black Dye or as a decorative element in more macabre builds. It is one of the few flowers that can be found in any dimension, provided a Wither has been summoned to create it."
+    },
+    "minecraft:cherry_sapling": {
+        id: "minecraft:cherry_sapling",
+        name: "Cherry Sapling",
+        hardness: 0,
+        blastResistance: 0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Cherry Sapling"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Cherry Grove biome"
+        },
+        description: "Cherry Sapling is a beautiful pink-flowered sapling introduced in the 1.20 Trails & Tales update. It grows naturally in the Cherry Grove biome and can be obtained by breaking or decaying Cherry Leaves. Unlike dark oak saplings, a single cherry sapling can grow into a full cherry tree, though it may take several growth stages. Its vibrant pink appearance makes it a popular choice for decorative landscaping and botanical gardens. Bone meal can be used to accelerate its growth into a mature cherry tree with its iconic falling leaf particles."
     }
 };

--- a/scripts/data/search/block_index.js
+++ b/scripts/data/search/block_index.js
@@ -2343,5 +2343,40 @@ export const blockIndex = [
         category: "block",
         icon: "textures/blocks/bamboo_slab",
         themeColor: "§e"
+    },
+    {
+        id: "minecraft:weeping_vines",
+        name: "Weeping Vines",
+        category: "block",
+        icon: "textures/items/weeping_vines",
+        themeColor: "§c"
+    },
+    {
+        id: "minecraft:crimson_fungus",
+        name: "Crimson Fungus",
+        category: "block",
+        icon: "textures/blocks/crimson_fungus",
+        themeColor: "§c"
+    },
+    {
+        id: "minecraft:warped_fungus",
+        name: "Warped Fungus",
+        category: "block",
+        icon: "textures/blocks/warped_fungus",
+        themeColor: "§3"
+    },
+    {
+        id: "minecraft:polished_basalt",
+        name: "Polished Basalt",
+        category: "block",
+        icon: "textures/blocks/polished_basalt_side",
+        themeColor: "§7"
+    },
+    {
+        id: "minecraft:cherry_sapling",
+        name: "Cherry Sapling",
+        category: "block",
+        icon: "textures/blocks/cherry_sapling",
+        themeColor: "§d"
     }
 ];


### PR DESCRIPTION
## Summary
Adding 5 new unique block entries for Minecraft Bedrock Edition: Weeping Vines, Crimson Fungus, Warped Fungus, Polished Basalt, and Cherry Sapling.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [ ] Mob
- [x] Block
- [ ] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs