### PR TITLE
Add 5 unique item entries: Pale Oak Boat, Pale Oak Chest Boat, Pale Oak Sign, Pale Oak Hanging Sign, Tipped Arrow

### DIFF
--- a/scripts/data/providers/items/misc/other.js
+++ b/scripts/data/providers/items/misc/other.js
@@ -1188,5 +1188,97 @@ export const miscItems = {
             "Nullifies fall damage for all passengers when falling from any height"
         ],
         description: "The Jungle Boat is a variant of the standard boat crafted from jungle planks. It offers the same reliable water transportation for two passengers as other wooden boats but features the distinct reddish-brown hue of jungle wood. This makes it an ideal choice for players navigating jungle rivers or seeking to match the aesthetic of jungle treehouses and builds. Like all boats in Bedrock Edition, it is crafted from five planks without a shovel and provides immunity to fall damage when occupied."
-    }
+    },
+    "minecraft:pale_oak_boat": {
+        id: "minecraft:pale_oak_boat",
+        name: "Pale Oak Boat",
+        maxStack: 1,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Water transportation for up to two entities",
+            secondaryUse: "Themed transportation for Pale Garden builds"
+        },
+        crafting: {
+            recipeType: "Shaped",
+            ingredients: ["Pale Oak Planks x5"]
+        },
+        specialNotes: [
+            "Matches the desaturated, grayish-white appearance of Pale Oak wood",
+            "Can carry two passengers, including players and mobs",
+            "Moves very fast on ice, especially blue ice",
+            "Nullifies fall damage for all occupants regardless of height",
+            "Introduced as part of the Pale Garden biome update (1.21.40+)"
+        ],
+        description: "The Pale Oak Boat is a specialized watercraft variant introduced alongside the Pale Garden biome. Crafted from five Pale Oak Planks, it features a unique ghostly, desaturated appearance that matches the wood of the Pale Oak tree. Like all Minecraft boats, it is a highly efficient way to travel across oceans and rivers, supporting up to two passengers. It also serves as an excellent traversal tool over ice and protects its occupants from fall damage, making it useful both on and off the water."
+    },
+    "minecraft:pale_oak_chest_boat": {
+        id: "minecraft:pale_oak_chest_boat",
+        name: "Pale Oak Chest Boat",
+        maxStack: 1,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Water transportation with mobile storage",
+            secondaryUse: "Transporting items and one passenger across Pale Garden"
+        },
+        crafting: {
+            recipeType: "Shapeless",
+            ingredients: ["Pale Oak Boat", "Chest"]
+        },
+        specialNotes: [
+            "Features a 27-slot inventory accessible while inside or outside the boat",
+            "Can only carry one passenger due to the space taken by the chest",
+            "Retains the grayish-white aesthetic of the Pale Oak wood set",
+            "Drops its contents and the chest boat item when destroyed",
+            "Ideal for transporting resources from the eerie Pale Garden biome"
+        ],
+        description: "The Pale Oak Chest Boat is mid-range transportation that combines the Pale Oak Boat with a standard Chest. This variant is perfect for expeditions into the Pale Garden, allowing players to carry up to 27 additional slots of resources while traveling. While it limits passenger capacity to one, its storage benefit is invaluable for long-range resource gathering. Its distinct pale gray appearance ensures it fits perfectly within the muted color palette of the 1.21.40 winter update content."
+    },
+    "minecraft:pale_oak_sign": {
+        id: "minecraft:pale_oak_sign",
+        name: "Pale Oak Sign",
+        maxStack: 16,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Displaying text on blocks or surfaces",
+            secondaryUse: "Directional markers and labeling storage"
+        },
+        crafting: {
+            recipeType: "Shaped",
+            ingredients: ["Pale Oak Planks x6", "Stick"]
+        },
+        specialNotes: [
+            "Can be placed on the top of blocks or on walls",
+            "Text can be edited after placement in Bedrock Edition",
+            "Dye can be used to change text color; Glow Ink Sac makes text glow",
+            "Both sides of the sign can have different text and colors",
+            "Signs can be locked by using honeycombs to prevent further editing"
+        ],
+        description: "The Pale Oak Sign is a classic messaging tool crafted from Pale Oak Planks. Its grayish-white wood provides a stark, clean background for text, making it highly readable. In Bedrock Edition, signs are versatile; they can be placed on almost any surface, and their text can be edited even after placement. Players can further customize them using dyes and glow ink sacs, or wax them with honeycombs to prevent further changes, making them essential for base organization and adventure map creation."
+    },
+    "minecraft:pale_oak_hanging_sign": {
+        id: "minecraft:pale_oak_hanging_sign",
+        name: "Pale Oak Hanging Sign",
+        maxStack: 16,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Displaying text hanging from blocks or side of blocks",
+            secondaryUse: "Aesthetic signage with a premium feel"
+        },
+        crafting: {
+            recipeType: "Shaped",
+            ingredients: ["Chain x2", "Stripped Pale Oak Log x6"]
+        },
+        specialNotes: [
+            "Can be hung from the bottom or side of blocks with a solid bracket",
+            "Requires Stripped Pale Oak Logs and Chains to craft",
+            "Functionally identical to standard signs but with a smaller text area",
+            "Matches the Pale Oak wood set for a consistent haunting aesthetic",
+            "Text can be applied to both sides, each with unique formatting"
+        ],
+        description: "The Pale Oak Hanging Sign is a decorative variant of the sign that hangs from chains. Crafted from Stripped Pale Oak Logs and Chains, it offers a more elegant and versatile way to display information in your world. It can be suspended from the underside of blocks or attached to the sides with a support bracket. Like standard signs, it supports dual-sided text entry, dye customization, and waxing. Its unique desaturated tone makes it a standout choice for markers within the Pale Garden biome."
+    },
 };

--- a/scripts/data/providers/items/weapons/projectiles.js
+++ b/scripts/data/providers/items/weapons/projectiles.js
@@ -66,6 +66,34 @@ export const projectiles = {
         ],
         description: "The Arrow is the fundamental ammunition for ranged combat in Minecraft, used with Bows, Crossbows, and Dispensers. It is crafted from flint, a stick, and a feather, producing four arrows per batch. In Bedrock Edition, arrows deal damage proportional to their velocity, and they can be tipped with potions to inflict status effects. Skeletons and Pillagers frequently drop them, making them a renewable resource even without crafting."
     },
+    "minecraft:tipped_arrow": {
+        id: "minecraft:tipped_arrow",
+        name: "Tipped Arrow",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Inflicting status effects on hit using a Bow or Crossbow",
+            secondaryUse: "Ammunition for Dispensers"
+        },
+        combat: {
+            attackDamage: 2, // Plus effect damage
+            attackSpeed: 0
+        },
+        crafting: {
+            recipeType: "Cauldron",
+            ingredients: ["Arrow x64", "Cauldron with Potion (1/3 bottle)"]
+        },
+        specialNotes: [
+            "In Bedrock Edition, they are crafted by using arrows on a cauldron containing a potion",
+            "One potion bottle in a cauldron can tip 16 arrows (8 in Java)",
+            "A full cauldron (3 bottles) can tip a full stack of 64 arrows",
+            "Effects include Swiftness, Harming, Healing, Poison, and more",
+            "The duration of the effect is generally 1/8th of the original potion",
+            "Cannot be retrieved after being fired from a Bow with Infinity"
+        ],
+        description: "Tipped arrows are specialized projectiles that deliver potion effects to the target they hit. Unlike Java Edition's crafting table recipe, Bedrock Edition players create them by dipping arrows into a cauldron filled with a potion. A single potion bottle can tip 16 arrows, making the process highly efficient. These arrows are essential for advanced combat strategies, allowing players to heal allies or apply debilitating debuffs from a distance. They are compatible with both Bows and Crossbows, though they cannot be recovered if shot from an Infinity-enchanted bow."
+    },
     "minecraft:snowball": {
         id: "minecraft:snowball",
         name: "Snowball",

--- a/scripts/data/search/item_index.js
+++ b/scripts/data/search/item_index.js
@@ -21,6 +21,13 @@ export const itemIndex = [
         themeColor: "§7" // gray
     },
     {
+        id: "minecraft:tipped_arrow",
+        name: "Tipped Arrow",
+        category: "item",
+        icon: "textures/items/arrow_tipped",
+        themeColor: "§f" // white/varies
+    },
+    {
         id: "minecraft:orange_dye",
         name: "Orange Dye",
         category: "item",
@@ -1495,7 +1502,35 @@ export const itemIndex = [
         name: "Bamboo Raft",
         category: "item",
         icon: "textures/items/boat_bamboo",
-        themeColor: "§e"
+        themeColor: "§e" // yellow
+    },
+    {
+        id: "minecraft:pale_oak_boat",
+        name: "Pale Oak Boat",
+        category: "item",
+        icon: "textures/items/boat_pale_oak",
+        themeColor: "§7" // gray/white
+    },
+    {
+        id: "minecraft:pale_oak_chest_boat",
+        name: "Pale Oak Chest Boat",
+        category: "item",
+        icon: "textures/items/boat_pale_oak_chest",
+        themeColor: "§7"
+    },
+    {
+        id: "minecraft:pale_oak_sign",
+        name: "Pale Oak Sign",
+        category: "item",
+        icon: "textures/items/sign_pale_oak",
+        themeColor: "§7"
+    },
+    {
+        id: "minecraft:pale_oak_hanging_sign",
+        name: "Pale Oak Hanging Sign",
+        category: "item",
+        icon: "textures/items/hanging_sign_pale_oak",
+        themeColor: "§7"
     },
     {
         id: "minecraft:boat_oar",


### PR DESCRIPTION
## Summary
Added 5 missing item entries from the 1.21.40+ (Winter Drop) update and a long-missing combat item.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [x] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs