### PR TITLE
feat: add 5 unique item entries (Round 3)

### DIFF
--- a/scripts/data/providers/items/materials/drops.js
+++ b/scripts/data/providers/items/materials/drops.js
@@ -155,6 +155,28 @@ export const mobDrops = {
         ],
         description: "Resin Clumps are resources obtained from the Creaking Heart and Creaking mobs in Pale Garden biomes. Attacking a Creaking Heart or a linked Creaking drops 1-3 clumps. These are used to craft Blocks of Resin (3x3 grid) or smelted into Resin Bricks. Introduced in the 1.21 update, this material allows players to incorporate the unique orange aesthetic of the Pale Garden into their builds. The harvesting process is tied to the interactive mechanics of the Creaking mob, rewarding players for engaging with this atmospheric threat."
     },
+    "minecraft:heavy_core": {
+        id: "minecraft:heavy_core",
+        name: "Heavy Core",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Crafting the Mace"
+        },
+        crafting: {
+            recipeType: "Loot",
+            ingredients: ["Ominous Vault (7.5% chance)"]
+        },
+        specialNotes: [
+            "Found exclusively in Ominous Vaults within Trial Chambers.",
+            "Required ingredient for crafting the Mace (combined with a Breeze Rod).",
+            "Functional as a decorative block that can be placed in any orientation.",
+            "It is a 'Rare' tier item.",
+            "Introduced in the 1.21 Tricky Trials update."
+        ],
+        description: "The Heavy Core is a dense, powerful artifact found deep within the Ominous Vaults of Trial Chambers. It is characterized by its significant weight and mysterious properties. When combined with a Breeze Rod at a crafting table, it forms the Mace, a powerful weapon that utilizes the player's falling momentum to deal massive damage. Its scarcity and the danger required to obtain it make it one of the most prestigious materials in the 1.21 update."
+    },
     "minecraft:blaze_rod": {
         id: "minecraft:blaze_rod",
         name: "Blaze Rod",

--- a/scripts/data/providers/items/misc/other.js
+++ b/scripts/data/providers/items/misc/other.js
@@ -1281,4 +1281,95 @@ export const miscItems = {
         ],
         description: "The Pale Oak Hanging Sign is a decorative variant of the sign that hangs from chains. Crafted from Stripped Pale Oak Logs and Chains, it offers a more elegant and versatile way to display information in your world. It can be suspended from the underside of blocks or attached to the sides with a support bracket. Like standard signs, it supports dual-sided text entry, dye customization, and waxing. Its unique desaturated tone makes it a standout choice for markers within the Pale Garden biome."
     },
+    "minecraft:crafter": {
+        id: "minecraft:crafter",
+        name: "Crafter",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Automating crafting recipes via redstone signals",
+            secondaryUse: "Compact automatic factory systems"
+        },
+        crafting: {
+            recipeType: "Shaped",
+            ingredients: ["5x Iron Ingot", "1x Crafting Table", "1x Redstone Dust", "2x Dropper"]
+        },
+        specialNotes: [
+            "Activated by a redstone pulse to craft one item.",
+            "Slots can be toggled 'on' or 'off' to define the recipe shape.",
+            "Pushes the crafted item into the world or an adjacent container.",
+            "Has a unique 'crushing' animation when crafting.",
+            "Introduced in the 1.21 Tricky Trials update."
+        ],
+        description: "The Crafter is a revolutionary utility block that brings automation to the crafting system. By supplying it with ingredients and a redstone signal, players can automate the production of any item in the game. Its interactive GUI allows players to disable specific slots, enabling complex recipes to be maintained without overflow. This block is the cornerstone of advanced technical Minecraft, allowing for the creation of fully autonomous farms and factories."
+    },
+    "minecraft:creaking_heart": {
+        id: "minecraft:creaking_heart",
+        name: "Creaking Heart",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Summoning the Creaking mob at night",
+            secondaryUse: "Decorative block and source of Resin"
+        },
+        crafting: {
+            recipeType: "Shaped",
+            ingredients: ["2x Pale Oak Log", "1x Block of Resin"]
+        },
+        specialNotes: [
+            "Must be placed between two Pale Oak Logs matching its orientation to activate.",
+            "Only active during the night; summons a protective Creaking mob.",
+            "If the heart is destroyed, the linked Creaking is also destroyed.",
+            "Drops Resin Clumps when attacked while active.",
+            "Obtainable by silk touch or by crafting with Resin."
+        ],
+        description: "The Creaking Heart is the haunting central core of the Creaking mob, found within the Pale Garden. It acts as a stationary summoner that manifests a Creaking to defend itself whenever it or its linked logs are disturbed. To function, it must be properly oriented between Pale Oak wood. During the night, it becomes a formidable barrier for explorers, but also a valuable source of Resin for those brave enough to harvest it. It represents the symbiotic relationship between the flora and the eerie residents of the Pale Garden."
+    },
+    "minecraft:open_eyeblossom": {
+        id: "minecraft:open_eyeblossom",
+        name: "Open Eyeblossom",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Crafting Gray Dye",
+            secondaryUse: "Decoration and particle emission"
+        },
+        crafting: {
+            recipeType: "Natural",
+            ingredients: ["Found in Pale Garden biomes"]
+        },
+        specialNotes: [
+            "Opens at night and closes during the day (becoming a Closed Eyeblossom).",
+            "Emits orange particles when open.",
+            "Can be planted on grass, dirt, or moss blocks.",
+            "When open, it can be crafted into Gray Dye; when closed, it crafts into Orange Dye.",
+            "Bees are not attracted to Eyeblossoms."
+        ],
+        description: "The Eyeblossom is a unique plant introduced in the 1.21.50 update, exclusive to the Pale Garden biome. It has a distinct lifecycle, opening its glowing orange 'eyes' only during the night and closing them during the day. This behavior makes it a striking decorative plant for spooky or atmospheric builds. Interestingly, players can obtain different dyes depending on whether the flower is open or closed, making its harvesting time a tactical choice. It adds a subtle but effective layer of mysticism to the desaturated landscape of the Pale Garden."
+    },
+    "minecraft:trial_explorer_map": {
+        id: "minecraft:trial_explorer_map",
+        name: "Trial Explorer Map",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Locating the nearest Trial Chamber",
+            secondaryUse: "Exploration and navigation"
+        },
+        crafting: {
+            recipeType: "Trade",
+            ingredients: ["12x Emerald", "1x Compass (Journeyman Cartographer)"]
+        },
+        specialNotes: [
+            "Displays a brown map icon for Trial Chambers.",
+            "Can be purchased from Journeyman-level Cartographer villagers.",
+            "Essential for finding Trial Chambers in worlds without using cheats or external tools.",
+            "Shows the structure's location relative to the player's position."
+        ],
+        description: "The Trial Explorer Map is a specialized navigation tool designed to lead players to Trial Chambers. By following the icon on the map, players can locate these massive underground structures and take on the challenges within. It is an indispensable resource for explorers who want to experience the 1.21 update's content without having to search aimlessly underground. This map is acquired through villager trading, specifically from Cartographers who have reached the Journeyman level."
+    },
 };

--- a/scripts/data/search/item_index.js
+++ b/scripts/data/search/item_index.js
@@ -112,6 +112,41 @@ export const itemIndex = [
         themeColor: "§5" // ominous purple
     },
     {
+        id: "minecraft:heavy_core",
+        name: "Heavy Core",
+        category: "item",
+        icon: "textures/blocks/heavy_core",
+        themeColor: "§7" // gray
+    },
+    {
+        id: "minecraft:crafter",
+        name: "Crafter",
+        category: "item",
+        icon: "textures/blocks/crafter_top",
+        themeColor: "§7" // gray
+    },
+    {
+        id: "minecraft:creaking_heart",
+        name: "Creaking Heart",
+        category: "item",
+        icon: "textures/blocks/creaking_heart",
+        themeColor: "§6" // resin orange
+    },
+    {
+        id: "minecraft:open_eyeblossom",
+        name: "Open Eyeblossom",
+        category: "item",
+        icon: "textures/blocks/eyeblossom_open",
+        themeColor: "§d" // light purple
+    },
+    {
+        id: "minecraft:trial_explorer_map",
+        name: "Trial Explorer Map",
+        category: "item",
+        icon: "textures/items/map_filled",
+        themeColor: "§6" // orange/map
+    },
+    {
         id: "minecraft:mace",
         name: "Mace",
         category: "item",


### PR DESCRIPTION
This PR adds 5 unique Minecraft Bedrock item entries to the search index and provider data:
1. **Crafter** - The new 1.21 automation block.
2. **Heavy Core** - The rare 1.21 material found in Ominous Vaults.
3. **Creaking Heart** - The central block of the new Pale Garden mob (1.21.50).
4. **Open Eyeblossom** - The day/night sensitive flower from the Pale Garden (1.21.50).
5. **Trial Explorer Map** - The map used to locate Trial Chambers.

### Changes:
- Added entries to `scripts/data/search/item_index.js` for all 5 items.
- Added detailed item profiles to `scripts/data/providers/items/materials/drops.js` and `scripts/data/providers/items/misc/other.js`.
- Verified that these items follow Bedrock Edition 1.21+ mechanics and stats.

These items were carefully selected to be distinct from those added in Round 1 and Round 2.