### PR TITLE
Add armor entries: Leather/Iron/Gold/Diamond Helmets and Leather Tunic

### DIFF
--- a/scripts/data/providers/items/armor/chestplates.js
+++ b/scripts/data/providers/items/armor/chestplates.js
@@ -10,6 +10,30 @@
  * @type {Object.<string, import('../../item_types').ItemDetails>}
  */
 export const chestplates = {
+    "minecraft:leather_chestplate": {
+        id: "minecraft:leather_chestplate",
+        name: "Leather Tunic",
+        maxStack: 1,
+        durability: 80,
+        enchantable: true,
+        usage: {
+            primaryUse: "Basic torso protection",
+            secondaryUse: "Freezing protection and decoration"
+        },
+        crafting: {
+            recipeType: "Shaped",
+            ingredients: ["Leather x8"]
+        },
+        specialNotes: [
+            "Provides 3 armor points (1.5 shield icons)",
+            "Protects the wearer from freezing damage in Powder Snow",
+            "Can be dyed millions of colors using a Cauldron in Bedrock Edition",
+            "Durability: 80",
+            "Repairable with Leather in an Anvil",
+            "Crafted using 8 pieces of Leather in a shaped pattern"
+        ],
+        description: "The Leather Tunic is a torso protection piece that provides 3 armor points. Beyond its survival utility, it is the only armor piece in Minecraft Bedrock Edition that protects the player from the freezing effect caused by Powder Snow. Like other leather armor, it can be dyed in a cauldron to create millions of unique colors, making it essential for both cold-weather exploration and decorative outfit design."
+    },
     "minecraft:chainmail_chestplate": {
         id: "minecraft:chainmail_chestplate",
         name: "Chainmail Chestplate",

--- a/scripts/data/providers/items/armor/helmets.js
+++ b/scripts/data/providers/items/armor/helmets.js
@@ -9,6 +9,102 @@
  * @type {Object.<string, import('../../item_types').ItemDetails>}
  */
 export const helmets = {
+    "minecraft:leather_helmet": {
+        id: "minecraft:leather_helmet",
+        name: "Leather Cap",
+        maxStack: 1,
+        durability: 55,
+        enchantable: true,
+        usage: {
+            primaryUse: "Basic head protection",
+            secondaryUse: "Team identification and decoration"
+        },
+        crafting: {
+            recipeType: "Shaped",
+            ingredients: ["Leather x5"]
+        },
+        specialNotes: [
+            "Provides 1 armor point (half a shield icon)",
+            "Can be dyed millions of colors using a Cauldron in Bedrock Edition",
+            "Durability: 55",
+            "Can be repaired using Leather in an Anvil",
+            "Does not protect against freezing in Powder Snow",
+            "Renewable via Cow, Mooshroom, or Hoglin drops"
+        ],
+        description: "The Leather Cap is the most basic form of head protection in Minecraft. While it only provides a single armor point and has a low durability of 55, it possesses a unique property: it can be dyed in over 12 million color combinations using a cauldron. This makes it a popular choice for team-based minigames and aesthetic customization. Despite its minimal defensive capabilities, it remains a staple for early-game survival and decorative armor sets."
+    },
+    "minecraft:iron_helmet": {
+        id: "minecraft:iron_helmet",
+        name: "Iron Helmet",
+        maxStack: 1,
+        durability: 165,
+        enchantable: true,
+        usage: {
+            primaryUse: "Reliable head protection in combat",
+            secondaryUse: "Trading and smelting for resources"
+        },
+        crafting: {
+            recipeType: "Shaped",
+            ingredients: ["Iron Ingot x5"]
+        },
+        specialNotes: [
+            "Provides 2 armor points (1 full shield icon)",
+            "Durability: 165",
+            "Can be repaired using Iron Ingots in an Anvil",
+            "Most common metal armor used by players in mid-game",
+            "Frequently dropped by armored Zombies and Skeletons",
+            "Can be melted down in a Furnace to yield one Iron Nugget"
+        ],
+        description: "The Iron Helmet is a solid mid-tier piece of armor that balances protection and cost. Providing 2 armor points—matching Golden and Turtle shells—it offers a much higher durability of 165 compared to gold. It is commonly one of the first metal armor pieces a player crafts due to the abundance of iron and its reliable performance in early-to-mid game survival and combat scenarios across the Overworld."
+    },
+    "minecraft:golden_helmet": {
+        id: "minecraft:golden_helmet",
+        name: "Golden Helmet",
+        maxStack: 1,
+        durability: 77,
+        enchantable: true,
+        usage: {
+            primaryUse: "Pacifying Piglins and head protection",
+            secondaryUse: "High-level enchantment base"
+        },
+        crafting: {
+            recipeType: "Shaped",
+            ingredients: ["Gold Ingot x5"]
+        },
+        specialNotes: [
+            "Provides 2 armor points (1 full shield icon)",
+            "Prevents Piglins from attacking the player in the Nether",
+            "Highest enchantability rating (25) of all helmet materials",
+            "Durability: 77 (lower than Iron's 165)",
+            "Can be melted down in a Furnace to yield one Gold Nugget",
+            "Repairable with Gold Ingots in an Anvil"
+        ],
+        description: "The Golden Helmet offers the same level of protection as an iron helmet but with significantly lower durability. Its primary strategic value is found in the Nether; wearing any piece of golden armor prevents Piglins from becoming aggressive. It also boasts the highest enchantability of any material, making it easier to obtain powerful enchantments like Protection IV at lower levels, though it will break much faster than iron or diamond."
+    },
+    "minecraft:diamond_helmet": {
+        id: "minecraft:diamond_helmet",
+        name: "Diamond Helmet",
+        maxStack: 1,
+        durability: 363,
+        enchantable: true,
+        usage: {
+            primaryUse: "High-level head protection",
+            secondaryUse: "Base for Netherite upgrade"
+        },
+        crafting: {
+            recipeType: "Shaped",
+            ingredients: ["Diamond x5"]
+        },
+        specialNotes: [
+            "Provides 3 armor points (1.5 shield icons) and 2 armor toughness",
+            "Durability: 363",
+            "Can be repaired with Diamonds in an Anvil",
+            "Renewable through Master-level Armorer villager trades",
+            "Base material required to upgrade to a Netherite Helmet",
+            "Offers superior protection against high-damage attacks due to toughness"
+        ],
+        description: "The Diamond Helmet is a high-tier protective item offering 3 armor points and 2 armor toughness. With a durability of 363, it is significantly more resilient than iron or gold alternatives. Until the discovery of ancient debris, it represents the strongest head protection available. It is often a priority for players entering dangerous late-game environments like the End or exploring Guardian-infested Ocean Monuments."
+    },
     "minecraft:chainmail_helmet": {
         id: "minecraft:chainmail_helmet",
         name: "Chainmail Helmet",

--- a/scripts/data/search/item_index.js
+++ b/scripts/data/search/item_index.js
@@ -2223,5 +2223,40 @@ export const itemIndex = [
         category: "item",
         icon: "textures/items/netherite_boots",
         themeColor: "§8" // dark gray/netherite
+    },
+    {
+        id: "minecraft:leather_helmet",
+        name: "Leather Cap",
+        category: "item",
+        icon: "textures/items/leather_helmet",
+        themeColor: "§6"
+    },
+    {
+        id: "minecraft:iron_helmet",
+        name: "Iron Helmet",
+        category: "item",
+        icon: "textures/items/iron_helmet",
+        themeColor: "§f"
+    },
+    {
+        id: "minecraft:golden_helmet",
+        name: "Golden Helmet",
+        category: "item",
+        icon: "textures/items/gold_helmet",
+        themeColor: "§e"
+    },
+    {
+        id: "minecraft:diamond_helmet",
+        name: "Diamond Helmet",
+        category: "item",
+        icon: "textures/items/diamond_helmet",
+        themeColor: "§b"
+    },
+    {
+        id: "minecraft:leather_chestplate",
+        name: "Leather Tunic",
+        category: "item",
+        icon: "textures/items/leather_chestplate",
+        themeColor: "§6"
     }
 ];


### PR DESCRIPTION
## Summary
Adding 5 new armor entries for Minecraft Bedrock Edition: Leather Cap, Iron Helmet, Golden Helmet, Diamond Helmet, and Leather Tunic.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [ ] Mob
- [ ] Block
- [x] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs