### PR TITLE
Add multiple item entries: Enderman, Dolphin, Warden, Allay, and Sniffer Spawn Eggs

### DIFF
--- a/scripts/data/providers/items/misc/spawn_eggs.js
+++ b/scripts/data/providers/items/misc/spawn_eggs.js
@@ -113,5 +113,110 @@ export const spawnEggs = {
             "Crucial for establishing villager populations in Creative."
         ],
         description: "The Villager Spawn Egg is a unique tool forsummoning Villagers without reproductive mechanics. When used on a surface, it creates a new Villager with a randomized biome outfit and profession (if nearby workstations allow). A unique feature of this egg is that using it on an existing adult Villager will instantly spawn a baby Villager of the same biome type. This allows for rapid population of custom-built villages in Creative Mode. It can also be used on Spawners, though Villager spawners are rarely used in standard play."
+    },
+    "minecraft:enderman_spawn_egg": {
+        id: "minecraft:enderman_spawn_egg",
+        name: "Enderman Spawn Egg",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Instantly spawning an Enderman mob",
+            secondaryUse: "Used on a Spawner to change its mob type"
+        },
+        crafting: {
+            recipeType: "Creative/Commands Only",
+            ingredients: []
+        },
+        specialNotes: [
+            "Available in the Creative Mode inventory.",
+            "Changes a Spawner's type to Enderman.",
+            "Endermen spawned this way will still teleport if provoked or in rain."
+        ],
+        description: "The Enderman Spawn Egg is a Creative-only item used to summon an Enderman. This tall, neutral mob from the End can be placed anywhere in the world using this egg. Map makers use it to populate dark areas or the End dimension with these teleporting creatures. Like other spawn eggs, applying it to a Monster Spawner will convert that spawner to produce Endermen, which is particularly useful for creating specialized ender pearl farms in custom environments."
+    },
+    "minecraft:dolphin_spawn_egg": {
+        id: "minecraft:dolphin_spawn_egg",
+        name: "Dolphin Spawn Egg",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Instantly spawning a Dolphin mob",
+            secondaryUse: "Used on a Spawner to change its mob type"
+        },
+        crafting: {
+            recipeType: "Creative/Commands Only",
+            ingredients: []
+        },
+        specialNotes: [
+            "Available to players in Creative Mode.",
+            "In Bedrock Edition, there is a 10% chance to spawn a baby dolphin.",
+            "Ensures dolphins can be placed in any water body for player assistance."
+        ],
+        description: "The Dolphin Spawn Egg allows for the immediate summoning of a Dolphin, a playful neutral mob found in ocean biomes. Using this egg in a body of water will place a dolphin that can grant the Dolphin's Grace effect to nearby swimming players. It is an essential tool for Creative players wanting to add life to their custom oceans or aquarium builds. When used on a Monster Spawner, it transforms it into a dolphin spawner, though these require water to function correctly."
+    },
+    "minecraft:warden_spawn_egg": {
+        id: "minecraft:warden_spawn_egg",
+        name: "Warden Spawn Egg",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Instantly spawning a Warden mob",
+            secondaryUse: "Used on a Spawner to change its mob type"
+        },
+        crafting: {
+            recipeType: "Creative/Commands Only",
+            ingredients: []
+        },
+        specialNotes: [
+            "Summons the most powerful non-boss mob in the game.",
+            "Wardens spawned via eggs do not emerge from the ground like natural ones.",
+            "Useful for testing Warden-related mechanics or complex redstone farms."
+        ],
+        description: "The Warden Spawn Egg is a specialized tool for summoning the Warden, the formidable guardian of the Deep Dark. Unlike naturally spawning Wardens that emerge when Sculk Shriekers are triggered, egg-spawned Wardens appear instantly on the targeted surface. This item is primarily used by developers and Creative builders to test combat systems or create high-stakes challenge maps. Using it on a Monster Spawner will set it to produce Wardens, creating an extremely dangerous area."
+    },
+    "minecraft:allay_spawn_egg": {
+        id: "minecraft:allay_spawn_egg",
+        name: "Allay Spawn Egg",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Instantly spawning an Allay mob",
+            secondaryUse: "Used on a Spawner to change its mob type"
+        },
+        crafting: {
+            recipeType: "Creative/Commands Only",
+            ingredients: []
+        },
+        specialNotes: [
+            "Available in Creative Mode for easy access to Allays.",
+            "Spawns the helpful, item-collecting Allay instantly.",
+            "Useful for setting up automated sorting systems in Creative builds."
+        ],
+        description: "The Allay Spawn Egg is used to summon an Allay, a helpful flying mob that can collect items for the player. Since Allays are normally found only in Pillager Outposts or Woodland Mansions, this egg provides a convenient way to obtain them in Creative Mode. Allays spawned this way function exactly like their naturally occurring counterparts, responding to Note Blocks and carrying items given to them. It can also be used to convert a Monster Spawner into an Allay spawner."
+    },
+    "minecraft:sniffer_spawn_egg": {
+        id: "minecraft:sniffer_spawn_egg",
+        name: "Sniffer Spawn Egg",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Instantly spawning a Sniffer mob",
+            secondaryUse: "Used on a Spawner to change its mob type"
+        },
+        crafting: {
+            recipeType: "Creative/Commands Only",
+            ingredients: []
+        },
+        specialNotes: [
+            "Introduced as part of the 1.20 Trails & Tales update.",
+            "Immediately summons a Sniffer, skipping the egg hatching process.",
+            "Can be used on baby Sniffers (Snifflets) or Spawners."
+        ],
+        description: "The Sniffer Spawn Egg allows players to instantly summon a Sniffer, an ancient mob that was once extinct. In Survival mode, Sniffers must be hatched from eggs found in warm ocean ruins, but this Creative-only item bypasses that time-consuming process. Once spawned, the Sniffer will behave normally, sniffing the ground to find ancient seeds like Torchflower Seeds or Pitcher Pods. Using this on a Monster Spawner will create a spawner that produces Sniffers continuously."
     }
 };

--- a/scripts/data/search/item_index.js
+++ b/scripts/data/search/item_index.js
@@ -168,6 +168,41 @@ export const itemIndex = [
         themeColor: "§6" // brown
     },
     {
+        id: "minecraft:enderman_spawn_egg",
+        name: "Enderman Spawn Egg",
+        category: "item",
+        icon: "textures/items/spawn_egg_enderman",
+        themeColor: "§5"
+    },
+    {
+        id: "minecraft:dolphin_spawn_egg",
+        name: "Dolphin Spawn Egg",
+        category: "item",
+        icon: "textures/items/spawn_egg_dolphin",
+        themeColor: "§b"
+    },
+    {
+        id: "minecraft:warden_spawn_egg",
+        name: "Warden Spawn Egg",
+        category: "item",
+        icon: "textures/items/spawn_egg_warden",
+        themeColor: "§8"
+    },
+    {
+        id: "minecraft:allay_spawn_egg",
+        name: "Allay Spawn Egg",
+        category: "item",
+        icon: "textures/items/spawn_egg_allay",
+        themeColor: "§d"
+    },
+    {
+        id: "minecraft:sniffer_spawn_egg",
+        name: "Sniffer Spawn Egg",
+        category: "item",
+        icon: "textures/items/spawn_egg_sniffer",
+        themeColor: "§2"
+    },
+    {
         id: "minecraft:netherite_upgrade_smithing_template",
         name: "Netherite Upgrade Smithing Template",
         category: "item",


### PR DESCRIPTION
## Summary
Adding 5 new spawn egg item entries (Enderman, Dolphin, Warden, Allay, and Sniffer) to improve the item coverage in the wiki.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [ ] Mob
- [ ] Block
- [x] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs