### PR TITLE
Add multiple item entries: Diamond Hoe, Enderman/Wither Skeleton/Guardian/Shulker Spawn Eggs

### DIFF
--- a/scripts/data/providers/items/misc/spawn_eggs.js
+++ b/scripts/data/providers/items/misc/spawn_eggs.js
@@ -323,5 +323,89 @@ export const spawnEggs = {
             "Changes a Spawner's type to Warden when used on it."
         ],
         description: "The Warden Spawn Egg creates a Warden instantly for testing encounters or building Deep Dark scenarios in Creative Mode. It is available through Creative or commands and places the Warden exactly where the egg is used. As with other spawn eggs, applying it to a Monster Spawner will convert that spawner to generate Wardens."
+    },
+    "minecraft:enderman_spawn_egg": {
+        id: "minecraft:enderman_spawn_egg",
+        name: "Enderman Spawn Egg",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Instantly spawning an Enderman mob",
+            secondaryUse: "Used on a Spawner to change its mob type"
+        },
+        crafting: {
+            recipeType: "Creative/Commands Only",
+            ingredients: []
+        },
+        specialNotes: [
+            "Creative/Commands-only item.",
+            "Spawns a neutral Enderman that teleports when wet or looked at.",
+            "Can be used on a Spawner to create an Enderman spawner."
+        ],
+        description: "The Enderman Spawn Egg is a Creative Mode item used to summon an Enderman. Endermen are neutral mobs that can teleport and pick up certain blocks. This egg is useful for testing teleportation mechanics or building custom End-themed encounters. Like other spawn eggs, it can also be used to modify the mob type of a Monster Spawner."
+    },
+    "minecraft:wither_skeleton_spawn_egg": {
+        id: "minecraft:wither_skeleton_spawn_egg",
+        name: "Wither Skeleton Spawn Egg",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Instantly spawning a Wither Skeleton mob",
+            secondaryUse: "Used on a Spawner to change its mob type"
+        },
+        crafting: {
+            recipeType: "Creative/Commands Only",
+            ingredients: []
+        },
+        specialNotes: [
+            "Creative/Commands-only item.",
+            "Wither Skeletons inflict the Wither effect on hit.",
+            "Essential for creating manual Wither Skeleton farms using spawners."
+        ],
+        description: "The Wither Skeleton Spawn Egg allows for the immediate summoning of a Wither Skeleton. These hostile mobs are typically found in Nether Fortresses and are known for their ability to inflict the Wither effect. This egg is primarily used in Creative Mode for map design or mob farm testing. Using it on a Monster Spawner will convert it into a Wither Skeleton spawner."
+    },
+    "minecraft:guardian_spawn_egg": {
+        id: "minecraft:guardian_spawn_egg",
+        name: "Guardian Spawn Egg",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Instantly spawning a Guardian mob",
+            secondaryUse: "Used on a Spawner to change its mob type"
+        },
+        crafting: {
+            recipeType: "Creative/Commands Only",
+            ingredients: []
+        },
+        specialNotes: [
+            "Creative/Commands-only item.",
+            "Spawns a Guardian, an aquatic hostile mob with a laser attack.",
+            "Does not spawn Elder Guardians (use separate egg)."
+        ],
+        description: "The Guardian Spawn Egg is used to summon a Guardian, an aquatic hostile mob found around Ocean Monuments. Guardians attack with a long-range laser and have thorns-like spikes when attacking. This egg is useful for creating underwater hazards in custom maps. It can also be used on a Monster Spawner to change its mob type to Guardian."
+    },
+    "minecraft:shulker_spawn_egg": {
+        id: "minecraft:shulker_spawn_egg",
+        name: "Shulker Spawn Egg",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Instantly spawning a Shulker mob",
+            secondaryUse: "Used on a Spawner to change its mob type"
+        },
+        crafting: {
+            recipeType: "Creative/Commands Only",
+            ingredients: []
+        },
+        specialNotes: [
+            "Creative/Commands-only item.",
+            "Shulkers fire levitation-inducing projectiles.",
+            "Can be used on a Spawner to create a Shulker spawner."
+        ],
+        description: "The Shulker Spawn Egg allows for the instantaneous placement of a Shulker. These mobs are found in End cities and are known for their shell-like appearance and projectiles that cause players to levitate. This egg is a valuable tool for Creative mode builders creating obstacle courses or protecting structures. Like all spawn eggs, it can be applied to a Monster Spawner."
     }
 };

--- a/scripts/data/providers/items/tools/hoes.js
+++ b/scripts/data/providers/items/tools/hoes.js
@@ -144,5 +144,32 @@ export const hoes = {
             "Frequently dropped by Piglins in the Nether."
         ],
         description: "The Golden Hoe is a fast but fragile farming tool. While it shares the same tilling capability as other hoes, it excels in its high enchantability, allowing for easier access to top-tier enchantments. However, its extremely low durability of just 32 uses makes it impractical for large-scale farming. It is often obtained via bartering with Piglins or found in Ruined Portal chests. In Bedrock, it provides minimal combat value with 2 attack damage."
+    },
+    "minecraft:diamond_hoe": {
+        id: "minecraft:diamond_hoe",
+        name: "Diamond Hoe",
+        maxStack: 1,
+        durability: 1562,
+        enchantable: true,
+        usage: {
+            primaryUse: "Tilling dirt and grass into farmland",
+            secondaryUse: "Fastest harvesting of leaves, sponges, and hay bales"
+        },
+        combat: {
+            attackDamage: 5,
+            attackSpeed: 0
+        },
+        crafting: {
+            recipeType: "Shaped",
+            ingredients: ["Diamond x2", "Stick x2"]
+        },
+        specialNotes: [
+            "High durability (1562 uses) in Bedrock Edition",
+            "Highest tier of hoe available without Netherite",
+            "Deals 5 attack damage (2.5 hearts) in Bedrock Edition",
+            "Greatly improves efficiency when mining Sculk and Shroomlights",
+            "Can be upgraded to a Netherite Hoe using a Smithing Template"
+        ],
+        description: "The Diamond Hoe is a high-tier agricultural tool that offers significant durability and harvesting speed. Crafted from two diamonds and two sticks, it is primarily used to till dirt and grass blocks into farmland. In Bedrock Edition, it also serves as a moderately effective weapon, dealing 5 points of damage. It is the most advanced hoe made of Overworld materials and is essential for clearing large amounts of vegetation or maintaining massive farms efficiently."
     }
 };

--- a/scripts/data/search/item_index.js
+++ b/scripts/data/search/item_index.js
@@ -2573,5 +2573,40 @@ export const itemIndex = [
         category: "item",
         icon: "textures/items/fish_tropical",
         themeColor: "§c"
+    },
+    {
+        id: "minecraft:diamond_hoe",
+        name: "Diamond Hoe",
+        category: "item",
+        icon: "textures/items/diamond_hoe",
+        themeColor: "§b"
+    },
+    {
+        id: "minecraft:enderman_spawn_egg",
+        name: "Enderman Spawn Egg",
+        category: "item",
+        icon: "textures/items/spawn_egg_enderman",
+        themeColor: "§8"
+    },
+    {
+        id: "minecraft:wither_skeleton_spawn_egg",
+        name: "Wither Skeleton Spawn Egg",
+        category: "item",
+        icon: "textures/items/spawn_egg_wither_skeleton",
+        themeColor: "§0"
+    },
+    {
+        id: "minecraft:guardian_spawn_egg",
+        name: "Guardian Spawn Egg",
+        category: "item",
+        icon: "textures/items/spawn_egg_guardian",
+        themeColor: "§3"
+    },
+    {
+        id: "minecraft:shulker_spawn_egg",
+        name: "Shulker Spawn Egg",
+        category: "item",
+        icon: "textures/items/spawn_egg_shulker",
+        themeColor: "§d"
     }
 ];


### PR DESCRIPTION
## Summary
Added 5 new unique item entries: Diamond Hoe (Bedrock Edition data), and Spawn Eggs for Enderman, Wither Skeleton, Guardian, and Shulker.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [ ] Mob
- [ ] Block
- [x] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs