### PR TITLE
feat: add 1.21 status potions and trial explorer map

### DIFF
--- a/scripts/data/providers/items/consumables/potions.js
+++ b/scripts/data/providers/items/consumables/potions.js
@@ -88,5 +88,93 @@ export const potions = {
             "Brewed using Dragon's Breath collected from the Ender Dragon"
         ],
         description: "Lingering Potions are advanced potion variants that create a cloud of status effect upon impact. They are brewed by combining a Splash Potion with Dragon's Breath. The resulting cloud persists for 30 seconds, applying the effect to any entity that passes through it. This area-of-effect mechanic makes them useful for zoning or sustaining buffs/debuffs. Additionally, Lingering Potions are the only way to craft Tipped Arrows, which imbue arrows with potion effects."
+    },
+    "minecraft:potion_infestation": {
+        id: "minecraft:potion_infestation",
+        name: "Potion of Infestation",
+        maxStack: 1,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Drinking to apply the Infested status effect",
+            secondaryUse: "Spawning Silverfish when taking damage"
+        },
+        crafting: {
+            recipeType: "Brewing",
+            ingredients: ["Stone + Awkward Potion"]
+        },
+        specialNotes: [
+            "Grants Infested: 10% chance to spawn 1-2 Silverfish on damage.",
+            "Brewed with a Stone block + Awkward Potion.",
+            "Duration: 3:00 (Regular) or 8:00 (Extended).",
+            "Can be turned into Splash/Lingering variants and Tipped Arrows."
+        ],
+        description: "The Potion of Infestation is a brewing item added in the 1.21 update. When consumed or applied via splash potion, it grants the Infested status effect. This effect causes entities to have a 10% chance to spawn 1-2 Silverfish when they take damage. It is brewed by adding a Stone block to an Awkward Potion in a brewing stand. This potion is particularly useful in mob farms or combat scenarios where extra mob disruption is desired. In Bedrock Edition, it behaves like other potions, being able to be used in cauldrons to tip arrows."
+    },
+    "minecraft:potion_oozing": {
+        id: "minecraft:potion_oozing",
+        name: "Potion of Oozing",
+        maxStack: 1,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Drinking to apply the Oozing status effect",
+            secondaryUse: "Spawning Slimes upon the death of an entity"
+        },
+        crafting: {
+            recipeType: "Brewing",
+            ingredients: ["Slime Block + Awkward Potion"]
+        },
+        specialNotes: [
+            "Grants Oozing: Spawns 2 medium Slimes on death.",
+            "Brewed with a Slime Block + Awkward Potion.",
+            "Duration: 3:00 (Regular) or 8:00 (Extended).",
+            "Effective for Slime farming automation."
+        ],
+        description: "The Potion of Oozing is an alchemical item introduced in 1.21. It applies the Oozing status effect, which causes an entity to spawn two Slimes upon death. This makes it an invaluable tool for Slime farming or for creating chaotic combat situations. It is brewed by combining a Slime Block with an Awkward Potion. Higher levels of the effect don't increase slime count, but extending the duration is possible with Redstone. Like all potions, it can be splashed or brewed into lingering clouds to affect groups of mobs or players efficiently."
+    },
+    "minecraft:potion_weaving": {
+        id: "minecraft:potion_weaving",
+        name: "Potion of Weaving",
+        maxStack: 1,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Drinking to apply the Weaving status effect",
+            secondaryUse: "Spawning Cobwebs upon death and moving faster through them"
+        },
+        crafting: {
+            recipeType: "Brewing",
+            ingredients: ["Cobweb + Awkward Potion"]
+        },
+        specialNotes: [
+            "Grants Weaving: Spawns 2-3 Cobwebs on death.",
+            "Allows entities to move faster through Cobwebs.",
+            "Brewed with a Cobweb + Awkward Potion.",
+            "Duration: 3:00 (Regular) or 8:00 (Extended)."
+        ],
+        description: "The Potion of Weaving is a technical potion introduced in the Tricky Trials update. It grants the Weaving effect, which causes entities to spawn 2-3 Cobweb blocks upon death and allows mobs to move through webs at a faster rate. It is brewed using a Cobweb with an Awkward Potion. This potion is a powerful utility in defense scenarios, slowing down attackers after they are defeated. In Bedrock Edition, the weaving effect can be used tacticaly to trap pursuers or create obstacles during large-scale battles."
+    },
+    "minecraft:potion_wind_charging": {
+        id: "minecraft:potion_wind_charging",
+        name: "Potion of Wind Charging",
+        maxStack: 1,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Drinking to apply the Wind Charged status effect",
+            secondaryUse: "Releasing a wind burst upon death"
+        },
+        crafting: {
+            recipeType: "Brewing",
+            ingredients: ["Breeze Rod + Awkward Potion"]
+        },
+        specialNotes: [
+            "Grants Wind Charged: Releases a wind burst on death.",
+            "Wind burst knocks back nearby entities.",
+            "Brewed with a Breeze Rod + Awkward Potion.",
+            "Duration: 3:00 (Regular) or 8:00 (Extended)."
+        ],
+        description: "The Potion of Wind Charging is a wind-themed alchemical item added in 1.21. It grants the Wind Charged effect, which causes an entity to release a wind burst upon death, similar to the projectile fired by a Breeze. This burst knocks back surrounding entities and can initiate chain reactions in groups of mobs. It is brewed by adding a Breeze Rod or Wind Charge to an Awkward Potion. This effect is highly strategic for keeping distance in group combat or disrupting mob formations."
     }
 };

--- a/scripts/data/providers/items/tools/utility.js
+++ b/scripts/data/providers/items/tools/utility.js
@@ -525,5 +525,27 @@ export const utilityTools = {
             "Essential for moving pufferfish to aquariums or defensive moats"
         ],
         description: "A Bucket of Pufferfish is a utility item used to safely transport pufferfish. It is obtained by using a water bucket on a swimming pufferfish. This item allows players to move these dangerous aquatic mobs without direct contact, which would otherwise inflict poison. When used, the bucket creates a water source block and releases the pufferfish. It is commonly used to create defensive moats or decorative aquariums, as pufferfish puff up when threatened."
+    },
+    "minecraft:trial_explorer_map": {
+        id: "minecraft:trial_explorer_map",
+        name: "Trial Explorer Map",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Locating the nearest Trial Chamber",
+            secondaryUse: "Navigation and structures finding"
+        },
+        crafting: {
+            recipeType: "Uncraftable",
+            ingredients: ["Purchased from journeyman-level Cartographer villagers"]
+        },
+        specialNotes: [
+            "Points to the nearest Trial Chamber.",
+            "Purchased from journeyman-level Cartographer villagers for 12 Emeralds and a Compass.",
+            "Highlights the chamber with a specific icon.",
+            "Useful for locating Tricky Trials content in Survival."
+        ],
+        description: "The Trial Explorer Map is a specialized navigation item obtained through trading with a journeyman-level Cartographer villager. It displays the location of the nearest Trial Chamber, marking it with a unique icon. Unlike regular maps, it is pre-filled with the topographical layout of the surrounding area relative to the chamber. It is essential for players seeking to conquer the combat challenges and rewards within Trial Chambers. In Bedrock Edition, it follows the locator map format, showing the player's position relative to the map's area."
     }
 };

--- a/scripts/data/search/item_index.js
+++ b/scripts/data/search/item_index.js
@@ -1120,6 +1120,13 @@ export const itemIndex = [
         themeColor: "§f" // paper/white
     },
     {
+        id: "minecraft:trial_explorer_map",
+        name: "Trial Explorer Map",
+        category: "item",
+        icon: "textures/items/map_filled",
+        themeColor: "§f"
+    },
+    {
         id: "minecraft:wheat",
         name: "Wheat",
         category: "item",
@@ -2329,6 +2336,34 @@ export const itemIndex = [
         category: "item",
         icon: "textures/items/potion_bottle_lingering",
         themeColor: "§d" // Pink
+    },
+    {
+        id: "minecraft:potion_infestation",
+        name: "Potion of Infestation",
+        category: "item",
+        icon: "textures/items/potion_bottle_drinkable",
+        themeColor: "§d"
+    },
+    {
+        id: "minecraft:potion_oozing",
+        name: "Potion of Oozing",
+        category: "item",
+        icon: "textures/items/potion_bottle_drinkable",
+        themeColor: "§d"
+    },
+    {
+        id: "minecraft:potion_weaving",
+        name: "Potion of Weaving",
+        category: "item",
+        icon: "textures/items/potion_bottle_drinkable",
+        themeColor: "§d"
+    },
+    {
+        id: "minecraft:potion_wind_charging",
+        name: "Potion of Wind Charging",
+        category: "item",
+        icon: "textures/items/potion_bottle_drinkable",
+        themeColor: "§d"
     },
     {
         id: "minecraft:pufferfish_bucket",


### PR DESCRIPTION
Added 5 unique items from the 1.21 Tricky Trials update that were missing from the database:
- Potion of Infestation
- Potion of Oozing
- Potion of Weaving
- Potion of Wind Charging
- Trial Explorer Map

All descriptions are under 600 characters and notes are under 120 characters per entry. Technical details reflect Bedrock Edition mechanics.