### PR TITLE
Add multiple block entries: Deepslate Ores and Copper variants

### DIFF
--- a/scripts/data/providers/blocks/building/copper.js
+++ b/scripts/data/providers/blocks/building/copper.js
@@ -78,6 +78,69 @@ export const copperBlocks = {
         },
         description: "Weathered Copper represents the second stage of copper oxidation, characterized by a distinct greenish-blue hue covering most of the block's surface. It naturally evolves from Exposed Copper over time but can be preserved by applying honeycomb. Using an axe on the block scrapes off the oxidation layer, reverting it to the Exposed stage. Mining requires a stone tier pickaxe or better. Its unique color makes it a popular choice for building roofs and statues that require an aged, historical aesthetic."
     },
+    "minecraft:oxidized_copper": {
+        id: "minecraft:oxidized_copper",
+        name: "Oxidized Copper",
+        hardness: 3.0,
+        blastResistance: 6.0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Stone",
+            silkTouch: false
+        },
+        drops: ["Oxidized Copper"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Weathered naturally (Final stage)"
+        },
+        description: "Oxidized Copper is the final stage of copper oxidation, featuring a beautiful teal-green patina that covers the entire block. It naturally forms from weathered copper when exposed to the elements for a long period. This block can be waxed with honeycomb to lock in its aged look or scraped with an axe to revert it to a previous oxidation stage. It is a favorite among builders for creating aged roofs, verdigris statues, and grand industrial structures."
+    },
+    "minecraft:cut_copper": {
+        id: "minecraft:cut_copper",
+        name: "Cut Copper",
+        hardness: 3.0,
+        blastResistance: 6.0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Stone",
+            silkTouch: false
+        },
+        drops: ["Cut Copper"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Crafted from Copper Blocks"
+        },
+        description: "Cut Copper is a decorative building block crafted by stonecutting or crafting from four blocks of copper. It features a unique tiled texture that makes it ideal for industrial flooring, modern roofs, and accent walls. Like regular copper blocks, cut copper undergoes four stages of oxidation, changing from orange to teal over time. It can be waxed to preserve a specific color or scraped to reverse the aging process."
+    },
+    "minecraft:oxidized_cut_copper": {
+        id: "minecraft:oxidized_cut_copper",
+        name: "Oxidized Cut Copper",
+        hardness: 3.0,
+        blastResistance: 6.0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Stone",
+            silkTouch: false
+        },
+        drops: ["Oxidized Cut Copper"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Weathered naturally (Final stage)"
+        },
+        description: "Oxidized Cut Copper is the final, fully aged form of cut copper blocks. It boasts a distinctive teal-green color while retaining its sharp, tiled texture. This block is perfect for adding a sense of history and permanence to a build, often used for turquoise-colored roofs or weathered pathways. It can be waxed to maintain its current state or scraped with an axe to reveal the layers of color beneath, providing builders with excellent gradient control."
+    },
     "minecraft:copper_bulb": {
         id: "minecraft:copper_bulb",
         name: "Copper Bulb",

--- a/scripts/data/providers/blocks/natural/ores.js
+++ b/scripts/data/providers/blocks/natural/ores.js
@@ -304,5 +304,47 @@ export const oreBlocks = {
             yRange: "-64 to 0 (deepslate layers)"
         },
         description: "Deepslate Redstone Ore is a variant of redstone ore that generates in the deepslate layers, appearing from Y=-64 up to Y=0. When stepped on or clicked, it glows and emits redstone particles. Mining it requires an iron pickaxe or better and yields 4-5 units of Redstone Dust, which can be increased with Fortune. This ore is a core component for advanced mechanics and automation. Its location at great depths makes it abundant for those exploring the deep dark or searching for diamonds near the world's bottom."
+    },
+    "minecraft:deepslate_lapis_ore": {
+        id: "minecraft:deepslate_lapis_ore",
+        name: "Deepslate Lapis Lazuli Ore",
+        hardness: 4.5,
+        blastResistance: 3.0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Iron",
+            silkTouch: true
+        },
+        drops: ["Lapis Lazuli (4-9, affected by Fortune)"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "-64 to 64"
+        },
+        description: "Deepslate Lapis Lazuli Ore is a tougher variant of the standard lapis ore, found deep within the Overworld's deepslate layers. It requires an iron pickaxe or better to mine. When broken, it yields a generous amount of lapis lazuli, which is essential for enchanting items and crafting blue dyes. Like other deepslate ores, it is more time-consuming to mine than its stone counterpart, but it offers the same valuable resources for any player venturing into the depths."
+    },
+    "minecraft:deepslate_emerald_ore": {
+        id: "minecraft:deepslate_emerald_ore",
+        name: "Deepslate Emerald Ore",
+        hardness: 4.5,
+        blastResistance: 3.0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Iron",
+            silkTouch: true
+        },
+        drops: ["Emerald (1, affected by Fortune)"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "-16 to 320 (Mountain biomes only)"
+        },
+        description: "Deepslate Emerald Ore is one of the rarest blocks in Minecraft, generating only in mountain biomes within the deepslate layers. It must be mined with an iron pickaxe or better. It drops a single emerald, the primary currency for trading with villagers. Because emeralds typically generate higher up, finding the deepslate variant is particularly rare. It is highly sought after by collectors and builders for its unique appearance and rarity."
     }
 };

--- a/scripts/data/search/block_index.js
+++ b/scripts/data/search/block_index.js
@@ -203,6 +203,27 @@ export const blockIndex = [
         themeColor: "§3" // dark aqua
     },
     {
+        id: "minecraft:oxidized_copper",
+        name: "Oxidized Copper",
+        category: "block",
+        icon: "textures/blocks/oxidized_copper",
+        themeColor: "§2" // dark green
+    },
+    {
+        id: "minecraft:cut_copper",
+        name: "Cut Copper",
+        category: "block",
+        icon: "textures/blocks/cut_copper",
+        themeColor: "§6" // copper/orange
+    },
+    {
+        id: "minecraft:oxidized_cut_copper",
+        name: "Oxidized Cut Copper",
+        category: "block",
+        icon: "textures/blocks/oxidized_cut_copper",
+        themeColor: "§2" // dark green
+    },
+    {
         id: "minecraft:iron_ore",
         name: "Iron Ore",
         category: "block",
@@ -999,6 +1020,20 @@ export const blockIndex = [
         category: "block",
         icon: "textures/blocks/deepslate_redstone_ore",
         themeColor: "§c" // red
+    },
+    {
+        id: "minecraft:deepslate_lapis_ore",
+        name: "Deepslate Lapis Lazuli Ore",
+        category: "block",
+        icon: "textures/blocks/deepslate_lapis_ore",
+        themeColor: "§1" // dark blue
+    },
+    {
+        id: "minecraft:deepslate_emerald_ore",
+        name: "Deepslate Emerald Ore",
+        category: "block",
+        icon: "textures/blocks/deepslate_emerald_ore",
+        themeColor: "§a" // green
     },
     {
         id: "minecraft:suspicious_gravel",


### PR DESCRIPTION
## Summary
Added 5 new unique block entries for Minecraft Bedrock: Deepslate Lapis Lazuli Ore, Deepslate Emerald Ore, Oxidized Copper, Cut Copper, and Oxidized Cut Copper.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [ ] Mob
- [x] Block
- [ ] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs