### PR TITLE
Add multiple block entries: Farmland, Dirt Path, Snow Block, White Glazed Terracotta, White Stained Glass

### DIFF
--- a/scripts/data/providers/blocks/building/glass.js
+++ b/scripts/data/providers/blocks/building/glass.js
@@ -50,5 +50,26 @@ export const glassBlocks = {
             yRange: "Crafted from Sand x4 in Furnace, Ocean Monuments (glass panes)"
         },
         description: "Glass is a fundamental transparent building block crafted by smelting sand in a furnace. It serves as a versatile construction material that allows light to pass through while providing weather protection. Glass is essential for building greenhouses, windows, modern architecture, and underwater structures. While fragile with low hardness and blast resistance (0.3 each), glass can be crafted into glass panes for more efficient space usage and lighter visual weight. Glass blocks are non-flammable and provide complete visibility from both sides. They're perfect for creating bright, airy interiors and are especially valuable for farming setups, aquariums, and decorative lighting effects. In Bedrock Edition, glass drops itself when broken, making collection straightforward without the need for Silk Touch enchantment."
+    },
+    "minecraft:white_stained_glass": {
+        id: "minecraft:white_stained_glass",
+        name: "White Stained Glass",
+        hardness: 0.3,
+        blastResistance: 0.3,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: true
+        },
+        drops: ["White Stained Glass (with Silk Touch)"],
+        generation: {
+            dimension: "None",
+            yRange: "Crafted from Glass x8 and White Dye"
+        },
+        description: "White Stained Glass is a transparent block created by surrounding a piece of White Dye with eight glass blocks. It retains the transparency of regular glass while adding a soft white tint, perfect for modern windows or decorative light filters. Like regular glass, it is fragile and requires a Silk Touch tool to be harvested; otherwise, it shatters when broken."
     }
 };

--- a/scripts/data/providers/blocks/building/misc.js
+++ b/scripts/data/providers/blocks/building/misc.js
@@ -112,5 +112,26 @@ export const miscBuildingBlocks = {
             yRange: "Badlands, Savanna Villages"
         },
         description: "Orange Terracotta is a vibrant, earth-toned block found abundantly in the Badlands biome and occasionally in savanna village houses. It is created by smelting clay and applying orange dye, or found naturally in massive strata. It features a warm, orange-brown hue that fits perfectly with desert or Mediterranean-style architecture. Like all terracotta variants, it has a hardness of 1.25 and requires a pickaxe for collection. Its matte texture is distinct from the glossy look of concrete, providing a more natural feel to builds. It can also be further smelted into orange glazed terracotta."
+    },
+    "minecraft:white_glazed_terracotta": {
+        id: "minecraft:white_glazed_terracotta",
+        name: "White Glazed Terracotta",
+        hardness: 1.4,
+        blastResistance: 1.4,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["White Glazed Terracotta"],
+        generation: {
+            dimension: "None",
+            yRange: "Smelted from White Terracotta"
+        },
+        description: "White Glazed Terracotta is a vibrant decorative block with a unique, ornate pattern. It is created by smelting white terracotta in a furnace. Like other glazed terracotta, it is immune to being moved by slime blocks or honey blocks, making it valuable for complex redstone machinery. Its directional placement allows players to create large, recurring patterns across floors and walls."
     }
 };

--- a/scripts/data/providers/blocks/natural/dirt.js
+++ b/scripts/data/providers/blocks/natural/dirt.js
@@ -325,5 +325,47 @@ export const dirtBlocks = {
             yRange: "Windswept Savanna, Wooded Badlands, Old Growth Taiga"
         },
         description: "Coarse Dirt is a variation of dirt that prevents grass from spreading onto it. It features a slightly darker and more textured appearance compared to regular dirt. It generates naturally in biomes where vegetation is sparse or the soil is rocky, such as Windswept Savannas and Old Growth Taigas. Players can also craft it by combining two dirt blocks with two gravel blocks. Tilling coarse dirt with a hoe converts it into regular dirt. It's an excellent choice for path-making and landscaping where a more rugged, earth-toned look is desired without the risk of grass overgrowth."
+    },
+    "minecraft:farmland": {
+        id: "minecraft:farmland",
+        name: "Farmland",
+        hardness: 0.6,
+        blastResistance: 0.6,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Dirt"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Villages"
+        },
+        description: "Farmland is a block created by using a hoe on dirt or grass blocks. It is essential for growing crops like wheat, carrots, potatoes, and pumpkins. Farmland must be hydrated by nearby water to remain productive; without water or crops, it eventually reverts to dirt. Walking or jumping on it can also turn it back into dirt."
+    },
+    "minecraft:dirt_path": {
+        id: "minecraft:dirt_path",
+        name: "Dirt Path",
+        hardness: 0.65,
+        blastResistance: 0.65,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Shovel",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Dirt"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Villages, Plains, Savanna"
+        },
+        description: "Dirt paths are decorative blocks created by using a shovel on grass blocks, dirt, podzol, or coarse dirt. They are slightly shorter than full blocks (15/16 height). Unlike grass, dirt paths provide a pleasant, trampled-earth look ideal for paths and roads in villages and landscapes."
     }
 };

--- a/scripts/data/providers/blocks/natural/ice.js
+++ b/scripts/data/providers/blocks/natural/ice.js
@@ -70,5 +70,26 @@ export const iceBlocks = {
             yRange: "Various heights in snowy biomes"
         },
         description: "Top Snow (also known as a Snow Layer) is a block that covers the ground in snowy biomes. In Bedrock Edition, snow layers are affected by gravity and will fall if the block beneath them is removed. A single layer of snow drops snowballs when mined with a shovel, unless Silk Touch is used. Multiple layers can be stacked to create a full snow block height. Snow layers will melt if the light level from a heat source (like torches or lava) is too high."
+    },
+    "minecraft:snow": {
+        id: "minecraft:snow",
+        name: "Snow Block",
+        hardness: 0.2,
+        blastResistance: 0.2,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Shovel",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["4x Snowball"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Snowy Biomes, Igloos"
+        },
+        description: "A Snow Block is a full-sized block crafted from four snowballs. It is primarily used for building and creating snow golems. Unlike snow layers, snow blocks are not affected by gravity and do not melt near light sources. They are easily broken with a shovel and are a common building material in cold biomes for creating igloos and snowy structures."
     }
 };

--- a/scripts/data/search/block_index.js
+++ b/scripts/data/search/block_index.js
@@ -2728,5 +2728,40 @@ export const blockIndex = [
         category: "block",
         icon: "textures/blocks/coarse_dirt",
         themeColor: "§6" // brown
+    },
+    {
+        id: "minecraft:farmland",
+        name: "Farmland",
+        category: "block",
+        icon: "textures/blocks/farmland_dry",
+        themeColor: "§6" // brown
+    },
+    {
+        id: "minecraft:dirt_path",
+        name: "Dirt Path",
+        category: "block",
+        icon: "textures/blocks/dirt_path_top",
+        themeColor: "§e" // yellow/brown
+    },
+    {
+        id: "minecraft:snow",
+        name: "Snow Block",
+        category: "block",
+        icon: "textures/blocks/snow",
+        themeColor: "§f" // white
+    },
+    {
+        id: "minecraft:white_glazed_terracotta",
+        name: "White Glazed Terracotta",
+        category: "block",
+        icon: "textures/blocks/glazed_terracotta_white",
+        themeColor: "§f" // white
+    },
+    {
+        id: "minecraft:white_stained_glass",
+        name: "White Stained Glass",
+        category: "block",
+        icon: "textures/blocks/glass_white",
+        themeColor: "§f" // white
     }
 ];


### PR DESCRIPTION
## Summary
Adding 5 new unique block entries for Minecraft Bedrock Edition to provide more comprehensive coverage of common natural and building blocks.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [ ] Mob
- [x] Block
- [ ] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs

**Blocks added:**
1. Farmland
2. Dirt Path
3. Snow Block
4. White Glazed Terracotta
5. White Stained Glass