### PR TITLE
Add multiple block entries: Pale Oak Door, Trapdoor, Fence, Fence Gate, Button

### DIFF
--- a/scripts/data/providers/blocks/decorative/misc.js
+++ b/scripts/data/providers/blocks/decorative/misc.js
@@ -579,5 +579,26 @@ export const miscDecorativeBlocks = {
             yRange: "Pillager Outposts, Ancient Cities, Villages"
         },
         description: "White Wool is a decorative building block obtained by shearing or killing white sheep, or by crafting four strings together. It is flammable and weak against explosions. In Bedrock Edition, wool has unique acoustic properties; it blocks vibrations from reaching Sculk Sensors and prevents Sculk Shriekers from detecting players walking on it. It can be dyed into 15 other colors. It generates naturally in Shepherd villager houses, woodland mansions, and pillager outposts."
+    },
+    "minecraft:pale_oak_fence": {
+        id: "minecraft:pale_oak_fence",
+        name: "Pale Oak Fence",
+        hardness: 2.0,
+        blastResistance: 3.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Pale Oak Fence"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Crafted from Pale Oak Planks and Sticks"
+        },
+        description: "Pale Oak Fences are thin, protective barrier blocks crafted from pale oak planks and sticks. They are 1.5 blocks high for most entities, preventing them from being jumped over. Naturally fitting the Pale Garden's somber aesthetic, these fences offer a ghostly, light gray alternative to traditional wood barriers. They connect automatically to adjacent fences, gates, and most solid blocks, making them perfect for atmospheric perimeters or detailed decorative railings."
     }
 };

--- a/scripts/data/providers/blocks/functional/interactive.js
+++ b/scripts/data/providers/blocks/functional/interactive.js
@@ -578,5 +578,68 @@ export const interactiveBlocks = {
             yRange: "Dungeons, Mineshafts, Strongholds, Bastion Remnants, Nether Fortresses"
         },
         description: "A Monster Spawner is a cage-like block that generates naturally in various structures. It contains a miniature, spinning mob inside and attempts to spawn that specific mob in a 9x9x3 area around itself whenever a player is within 16 blocks. Spawners are invaluable for creating automated mob farms for experience and items. In survival mode, they cannot be obtained as an item, even with Silk Touch, and drop only experience when broken with a pickaxe. The spawn rate depends on light levels and whether the maximum mob density for that area has been reached."
+    },
+    "minecraft:pale_oak_door": {
+        id: "minecraft:pale_oak_door",
+        name: "Pale Oak Door",
+        hardness: 3.0,
+        blastResistance: 3.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Pale Oak Door"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Crafted from Pale Oak Planks"
+        },
+        description: "A Pale Oak Door is a decorative and functional block crafted from six pale oak planks. It features a muted, desaturated gray-white color that matches the eerie aesthetic of the Pale Garden biome. Like other wooden doors, it can be opened by hand or powered by redstone. It occupies a two-block high space and provides a ghostly, elegant entrance to any build."
+    },
+    "minecraft:pale_oak_trapdoor": {
+        id: "minecraft:pale_oak_trapdoor",
+        name: "Pale Oak Trapdoor",
+        hardness: 3.0,
+        blastResistance: 3.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Pale Oak Trapdoor"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Crafted from Pale Oak Planks"
+        },
+        description: "The Pale Oak Trapdoor is a horizontal variant of the pale oak wood set. It shares the characteristic ghostly palette of the Pale Garden. Crafted from six pale oak planks, it functions as a one-block opening that can be toggled by player interaction or redstone signals. Its desaturated appearance makes it ideal for subtle flooring details, hidden passages, or unique architectural accents in more somber or weathered building designs."
+    },
+    "minecraft:pale_oak_fence_gate": {
+        id: "minecraft:pale_oak_fence_gate",
+        name: "Pale Oak Fence Gate",
+        hardness: 2.0,
+        blastResistance: 3.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Pale Oak Fence Gate"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Crafted from Pale Oak Planks and Sticks"
+        },
+        description: "A Pale Oak Fence Gate serves as an interactive entrance through fence perimeters. Matching the Pale Oak wood set, it displays a light, ghostly gray-white hue. It can be opened and closed by hand or via redstone, and always opens away from the player. When placed, it provides a seamless transition for pale oak fences while maintaining the desaturated, atmospheric look of the Pale Garden biome."
     }
 };

--- a/scripts/data/providers/blocks/functional/redstone.js
+++ b/scripts/data/providers/blocks/functional/redstone.js
@@ -411,5 +411,26 @@ export const redstoneBlocks = {
             yRange: "Crafted; Desert Pyramids, Jungle Temples"
         },
         description: "The Wooden Button is a redstone switch that provides a 30 redstone tick pulse when pressed, longer than the stone button's 20 ticks. Activated by hand or projectile, it serves as a temporary power source for doors, trapdoors, and other redstone mechanisms. In Bedrock Edition, wooden buttons can be crafted from any wood type and occasionally generate naturally in desert pyramids and jungle temples. Their extended pulse duration makes them particularly useful for timing-sensitive circuits and contraptions."
+    },
+    "minecraft:pale_oak_button": {
+        id: "minecraft:pale_oak_button",
+        name: "Pale Oak Button",
+        hardness: 0.5,
+        blastResistance: 0.5,
+        flammability: true,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Pale Oak Button"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Crafted from Pale Oak Planks"
+        },
+        description: "The Pale Oak Button is a compact redstone power source crafted from a single pale oak plank. It provides a momentary redstone pulse when pressed, lasting for 15 ticks (1.5 seconds) in Bedrock Edition. Its muted, cream-gray color allows it to blend subtly with other pale oak blocks or stand out against darker materials. It can be placed on any side of a solid block, making it a versatile tool for activating doors, machines, or hidden mechanisms."
     }
 };

--- a/scripts/data/search/block_index.js
+++ b/scripts/data/search/block_index.js
@@ -2833,5 +2833,40 @@ export const blockIndex = [
         category: "block",
         icon: "textures/blocks/leaves_acacia",
         themeColor: "§2" // green
+    },
+    {
+        id: "minecraft:pale_oak_door",
+        name: "Pale Oak Door",
+        category: "block",
+        icon: "textures/items/pale_oak_door",
+        themeColor: "§7"
+    },
+    {
+        id: "minecraft:pale_oak_trapdoor",
+        name: "Pale Oak Trapdoor",
+        category: "block",
+        icon: "textures/blocks/pale_oak_trapdoor",
+        themeColor: "§7"
+    },
+    {
+        id: "minecraft:pale_oak_fence",
+        name: "Pale Oak Fence",
+        category: "block",
+        icon: "textures/blocks/pale_oak_fence",
+        themeColor: "§7"
+    },
+    {
+        id: "minecraft:pale_oak_fence_gate",
+        name: "Pale Oak Fence Gate",
+        category: "block",
+        icon: "textures/blocks/pale_oak_fence_gate",
+        themeColor: "§7"
+    },
+    {
+        id: "minecraft:pale_oak_button",
+        name: "Pale Oak Button",
+        category: "block",
+        icon: "textures/blocks/pale_oak_button",
+        themeColor: "§7"
     }
 ];


### PR DESCRIPTION
## Summary
Added 5 new unique block entries from the Pale Garden biome (Minecraft Bedrock 1.21.40+). These include the Pale Oak Door, Trapdoor, Fence, Fence Gate, and Button.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [x] Block

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs