### PR TITLE
Add multiple block entries: Sugar Cane, Bamboo, and Infested variants

### DIFF
--- a/scripts/data/providers/blocks/building/bricks.js
+++ b/scripts/data/providers/blocks/building/bricks.js
@@ -829,5 +829,68 @@ export const brickBlocks = {
             yRange: "32–96 (Bastion Remnants)"
         },
         description: "Chiseled Quartz Block is a decorative variant of the Quartz Block featuring an intricate, square-patterned carving. It is crafted by stacking two quartz slabs vertically in a crafting grid or by using a stonecutter. While primarily used for aesthetic purposes in modern and classical architecture, it generates naturally in bastion remnants. Like other quartz blocks, it has a hardness of 0.8 and require a pickaxe to mine. Its bright white appearance and unique geometric design make it ideal for decorative trims, pillars, and ornate flooring in high-end Minecraft constructions."
+    },
+    "minecraft:infested_stone_bricks": {
+        id: "minecraft:infested_stone_bricks",
+        name: "Infested Stone Bricks",
+        hardness: 0.0,
+        blastResistance: 0.75,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["None (spawns Silverfish), Stone Bricks (with Silk Touch)"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Strongholds"
+        },
+        description: "Infested Stone Bricks are deceptive blocks that house silverfish. While shielding their inhabitant, they appear identical to regular stone bricks, but in Bedrock Edition, they can be distinguished by their near-instant breaking time (hardness 0.0). When mined without Silk Touch, the block is destroyed and a hostile silverfish is released. They generate naturally within the walls and floors of Strongholds, often surprising players as they explore toward the end portal."
+    },
+    "minecraft:infested_mossy_stone_bricks": {
+        id: "minecraft:infested_mossy_stone_bricks",
+        name: "Infested Mossy Stone Bricks",
+        hardness: 0.0,
+        blastResistance: 0.75,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["None (spawns Silverfish), Mossy Stone Bricks (with Silk Touch)"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Strongholds"
+        },
+        description: "Infested Mossy Stone Bricks are a variation of infested blocks containing silverfish. They mimic the look of aged, moss-covered stone bricks found in Strongholds. Like other infested blocks in Bedrock Edition, they have zero hardness, meaning they break significantly faster than their non-infested counterparts. Breaking one without Silk Touch releases a silverfish, which can alert other nearby silverfish hidden in infested blocks, potentially leading to a dangerous swarm."
+    },
+    "minecraft:infested_cracked_stone_bricks": {
+        id: "minecraft:infested_cracked_stone_bricks",
+        name: "Infested Cracked Stone Bricks",
+        hardness: 0.0,
+        blastResistance: 0.75,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["None (spawns Silverfish), Cracked Stone Bricks (with Silk Touch)"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Strongholds"
+        },
+        description: "Infested Cracked Stone Bricks appear as worn, fractured blocks but secretly contain silverfish. They are most commonly encountered in Strongholds. In Bedrock Edition, their lack of hardness makes them easy to identify if a player pays attention to mining speed. If broken, they release a silverfish and drop nothing. Using Silk Touch allows the collection of the regular cracked stone brick block. These blocks add an element of danger to exploring the subterranean ruins of strongholds."
     }
 };

--- a/scripts/data/providers/blocks/natural/vegetation.js
+++ b/scripts/data/providers/blocks/natural/vegetation.js
@@ -1065,5 +1065,47 @@ export const vegetationBlocks = {
             yRange: "Plains, Savannas, Jungles"
         },
         description: "Tall Grass is a two-block high variant of grass that generates naturally in various biomes like Plains, Savannas, and Jungles. Unlike regular short grass, it provides more visual density to the landscape. When broken by hand, it has a chance to drop wheat seeds, but it must be harvested with Shears to be collected as an item. It can be grown by applying bone meal to short grass or directly to a grass block. Its height makes it useful for creating overgrown aesthetics or providing camouflage in survival situations."
+    },
+    "minecraft:reeds": {
+        id: "minecraft:reeds",
+        name: "Sugar Cane",
+        hardness: 0,
+        blastResistance: 0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Sugar Cane"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Found near water on grass, sand, or dirt"
+        },
+        description: "Sugar Cane is a 1-block wide plant that grows up to 3 blocks high (occasionally 4 in world generation) when adjacent to a water source. It is essential for crafting paper and sugar, making it vital for enchanting and potion-making. In Bedrock Edition, sugar cane can also be grown using bone meal to instantly increase its height. It can only be placed on grass blocks, sand, red sand, podzol, or dirt that is directly next to water."
+    },
+    "minecraft:bamboo": {
+        id: "minecraft:bamboo",
+        name: "Bamboo",
+        hardness: 1.0,
+        blastResistance: 1.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Sword",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Bamboo"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Jungle and Bamboo Jungle biomes"
+        },
+        description: "Bamboo is the fastest-growing plant in Minecraft, primarily found in jungle biomes and especially dense in bamboo jungles. It can grow up to 12-16 blocks tall and can be harvested instantly with a sword. Bamboo is incredibly versatile: it's used to breed pandas, smelted as fuel, or crafted into scaffolding, sticks, and the bamboo wood set (introduced in 1.20). Since update 1.14, it has been an essential resource for players looking for efficient scaffolding and sustainable wood sources."
     }
 };

--- a/scripts/data/search/block_index.js
+++ b/scripts/data/search/block_index.js
@@ -2868,5 +2868,40 @@ export const blockIndex = [
         category: "block",
         icon: "textures/blocks/pale_oak_button",
         themeColor: "§7"
+    },
+    {
+        id: "minecraft:reeds",
+        name: "Sugar Cane",
+        category: "block",
+        icon: "textures/blocks/reeds",
+        themeColor: "§2"
+    },
+    {
+        id: "minecraft:bamboo",
+        name: "Bamboo",
+        category: "block",
+        icon: "textures/blocks/bamboo",
+        themeColor: "§2"
+    },
+    {
+        id: "minecraft:infested_stone_bricks",
+        name: "Infested Stone Bricks",
+        category: "block",
+        icon: "textures/blocks/stone_bricks",
+        themeColor: "§7"
+    },
+    {
+        id: "minecraft:infested_mossy_stone_bricks",
+        name: "Infested Mossy Stone Bricks",
+        category: "block",
+        icon: "textures/blocks/mossy_stone_bricks",
+        themeColor: "§2"
+    },
+    {
+        id: "minecraft:infested_cracked_stone_bricks",
+        name: "Infested Cracked Stone Bricks",
+        category: "block",
+        icon: "textures/blocks/cracked_stone_bricks",
+        themeColor: "§7"
     }
 ];


### PR DESCRIPTION
## Summary
Added 5 new unique block entries to the wiki: Sugar Cane, Bamboo, and three variants of Infested Stone Bricks.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [ ] Mob
- [x] Block
- [ ] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs