### PR TITLE
Add multiple block entries: Dandelion, Poppy, Sugar Cane, Bamboo, and Dragon Egg

### DIFF
--- a/scripts/data/providers/blocks/dimension/end.js
+++ b/scripts/data/providers/blocks/dimension/end.js
@@ -261,5 +261,27 @@ export const endBlocks = {
             yRange: "75 (Main Island) / Various (Outer Islands)"
         },
         description: "The End Gateway is a small, indestructible portal block that facilitates travel between the main End island and outer islands. It generates when the Ender Dragon is defeated. Players can enter by throwing an ender pearl into the gap or by using a trapdoor to crawl through. It emits a powerful light level of 15 and features a unique end galaxy texture. This block is essential for exploring the vast outer reaches of the End where End Cities and Chorus Plants are found."
+    },
+    "minecraft:dragon_egg": {
+        id: "minecraft:dragon_egg",
+        name: "Dragon Egg",
+        hardness: 3.0,
+        blastResistance: 9.0,
+        flammability: false,
+        gravityAffected: true,
+        transparent: true,
+        luminance: 1,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Dragon Egg"],
+        generation: {
+            dimension: "The End",
+            yRange: "Exit portal (0, 0) after defeating the Ender Dragon"
+        },
+        description: "The Dragon Egg is a rare trophy block and the single rarest item in Minecraft, appearing on top of the exit portal in the End dimension after the player defeats the Ender Dragon for the first time. It is primarily decorative and serves as a badge of honor. When clicked, it teleports to a nearby location, making it tricky to collect without a piston or by digging beneath it. It emits a very faint light level of 1 and is unaffected by the Ender Dragon's breath or standard explosions. It is one of the few blocks in the game that is completely unique in a survival world."
     }
 };
+

--- a/scripts/data/providers/blocks/natural/vegetation.js
+++ b/scripts/data/providers/blocks/natural/vegetation.js
@@ -1128,5 +1128,89 @@ export const vegetationBlocks = {
             yRange: "Taiga, Jungle, Flower Forest"
         },
         description: "Ferns are decorative vegetation blocks that add texture and detail to forest floors, especially in Taiga and Jungle biomes. They share properties with tall grass, appearing as small, bushy green plants. While they don't produce unique items, they can be harvested with shears for use in landscaping or placed in flower pots. Using bone meal on a fern will transform it into a Large Fern, which is two blocks tall. They are a staple for builders looking to create organic environments."
+    },
+    "minecraft:dandelion": {
+        id: "minecraft:dandelion",
+        name: "Dandelion",
+        hardness: 0,
+        blastResistance: 0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Dandelion"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Plains, Forests, and Mountain Meadow biomes"
+        },
+        description: "Dandelions are common, bright yellow flowers found in many Overworld biomes like Plains and Forests. They can be crafted into yellow dye or used to make suspicious stew that provides health restoration. Dandelions are also used for breeding bees and can be placed in flower pots for decoration. When bone meal is used on a grass block in their native biomes, they have a chance to generate naturally. In Bedrock Edition, they are a simple yet versatile plant for adding color to landscapes and gardens."
+    },
+    "minecraft:poppy": {
+        id: "minecraft:poppy",
+        name: "Poppy",
+        hardness: 0,
+        blastResistance: 0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Poppy"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Forests, Plains, and Sunflower Plains biomes"
+        },
+        description: "Poppies are vibrant red flowers that generate naturally in many grassy biomes across the Overworld. They are a primary source of red dye and can be used to craft suspicious stew that grants Night Vision in Bedrock Edition. Iron Golems are occasionally seen holding poppies, and they will drop 0-1 poppy when defeated. Like other small flowers, they can be placed in flower pots and are attractive to bees. They are easy to find and serve as an essential decorative element for players looking to add a touch of red to their environment."
+    },
+    "minecraft:sugar_cane": {
+        id: "minecraft:sugar_cane",
+        name: "Sugar Cane",
+        hardness: 0,
+        blastResistance: 0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Sugar Cane"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Near water sources in most biomes"
+        },
+        description: "Sugar Cane is a valuable plant block found naturally along the edges of rivers and oceans, growing on sand, dirt, or grass directly adjacent to water. It can grow up to three blocks high naturally, or higher if placed manually by the player. It is a vital resource for crafting paper and sugar, making it essential for early-game exploration (maps) and late-game enchantment (bookshelves). In Bedrock Edition, sugar cane can also be grown using bone meal, allowing for fast and efficient harvesting in automated farms."
+    },
+    "minecraft:bamboo": {
+        id: "minecraft:bamboo",
+        name: "Bamboo",
+        hardness: 1.0,
+        blastResistance: 1.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Sword",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Bamboo"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Jungle and Bamboo Jungle biomes"
+        },
+        description: "Bamboo is a fast-growing plant found abundantly in Jungle and Bamboo Jungle biomes. It can grow up to 12-16 blocks tall and is the primary food source for Pandas. When harvested, it can be used to craft scaffolding, sticks, and various bamboo-based wood blocks like planks and slabs. Bamboo is also a highly efficient fuel source for furnaces. It can be planted on many blocks, including grass, dirt, and sand, and its growth can be significantly accelerated using bone meal. In Bedrock Edition, a sword is the most effective tool for instantly breaking bamboo."
     }
 };

--- a/scripts/data/search/block_index.js
+++ b/scripts/data/search/block_index.js
@@ -2924,5 +2924,40 @@ export const blockIndex = [
         category: "block",
         icon: "textures/blocks/fern",
         themeColor: "§2"
+    },
+    {
+        id: "minecraft:dandelion",
+        name: "Dandelion",
+        category: "block",
+        icon: "textures/blocks/flower_dandelion",
+        themeColor: "§e" // yellow
+    },
+    {
+        id: "minecraft:poppy",
+        name: "Poppy",
+        category: "block",
+        icon: "textures/blocks/flower_rose",
+        themeColor: "§c" // red
+    },
+    {
+        id: "minecraft:sugar_cane",
+        name: "Sugar Cane",
+        category: "block",
+        icon: "textures/blocks/reeds",
+        themeColor: "§a" // green
+    },
+    {
+        id: "minecraft:bamboo",
+        name: "Bamboo",
+        category: "block",
+        icon: "textures/blocks/bamboo_stem",
+        themeColor: "§2" // dark green
+    },
+    {
+        id: "minecraft:dragon_egg",
+        name: "Dragon Egg",
+        category: "block",
+        icon: "textures/blocks/dragon_egg",
+        themeColor: "§5" // dark purple
     }
 ];


### PR DESCRIPTION
## Summary
Added 5 new unique block entries to the index: Dandelion, Poppy, Sugar Cane, Bamboo, and Dragon Egg.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [x] Block

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs