### PR TITLE
Add 5 unique block entries: Weighted Pressure Plates, Blackstone Button, and Nether Doors

### DIFF
--- a/scripts/data/providers/blocks/dimension/nether.js
+++ b/scripts/data/providers/blocks/dimension/nether.js
@@ -725,5 +725,47 @@ export const netherBlocks = {
             yRange: "48–72 (Nether Fortresses)"
         },
         description: "Nether Brick Fence is a dark, fire-resistant barrier block found naturally in Nether Fortresses. Unlike wooden fences, it is immune to fire and cannot be burned, making it a superior choice for building in the Nether or near lava. It has a higher blast resistance than most Overworld fences and requires a pickaxe to mine. While it does not connect to wooden fences, it connects to most solid blocks and other nether brick fence pieces. It is crafted from nether bricks and nether brick items, providing a sturdy and atmospheric defensive perimeter for any fortress or dark-themed build."
+    },
+    "minecraft:warped_door": {
+        id: "minecraft:warped_door",
+        name: "Warped Door",
+        hardness: 3,
+        blastResistance: 3,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Warped Door"],
+        generation: {
+            dimension: "Nether",
+            yRange: "Crafted from Warped Planks"
+        },
+        description: "The Warped Door is a unique, fireproof door crafted from warped planks found in the Nether's Warped Forest. Unlike Overworld wooden doors, it does not burn or catch fire, making it an essential building component for bases in the Nether. It features a striking teal color and a strange, alien-like texture that matches the warped wood family. Functionally, it behaves like a standard door that players can open and close manually, but its resistance to fire and lava provides superior protection in hazardous environments."
+    },
+    "minecraft:crimson_door": {
+        id: "minecraft:crimson_door",
+        name: "Crimson Door",
+        hardness: 3,
+        blastResistance: 3,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Crimson Door"],
+        generation: {
+            dimension: "Nether",
+            yRange: "Crafted from Crimson Planks"
+        },
+        description: "The Crimson Door is a fire-resistant door made from crimson planks, native to the Crimson Forest biomes in the Nether. It shares the fireproof properties of all Nether wood types, ensuring it remains intact even when exposed to nearby lava or fire. Its deep maroon and red hues provide a dark, rustic aesthetic that complements netherrack and blackstone builds. Like other doors in Bedrock Edition, it can be used to block mob pathfinding and can be opened by hand or with redstone signals, all while resisting the Nether's heat."
     }
 };

--- a/scripts/data/providers/blocks/functional/redstone.js
+++ b/scripts/data/providers/blocks/functional/redstone.js
@@ -432,5 +432,68 @@ export const redstoneBlocks = {
             yRange: "Crafted from Pale Oak Planks"
         },
         description: "The Pale Oak Button is a compact redstone power source crafted from a single pale oak plank. It provides a momentary redstone pulse when pressed, lasting for 15 ticks (1.5 seconds) in Bedrock Edition. Its muted, cream-gray color allows it to blend subtly with other pale oak blocks or stand out against darker materials. It can be placed on any side of a solid block, making it a versatile tool for activating doors, machines, or hidden mechanisms."
+    },
+    "minecraft:light_weighted_pressure_plate": {
+        id: "minecraft:light_weighted_pressure_plate",
+        name: "Light Weighted Pressure Plate",
+        hardness: 0.5,
+        blastResistance: 0.5,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["Light Weighted Pressure Plate"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Crafted from Gold Ingots"
+        },
+        description: "A Light Weighted Pressure Plate (Gold) is a specialized redstone component that outputs a signal strength based on the number of entities standing on it. In Bedrock Edition, it emits a signal strength equal to the number of entities, up to a maximum of 15. This allows for precise entity counting in automated systems. It can detect all entities, including players, mobs, and dropped items, making it essential for complex mob farms and item sorters that require specific quantity detection."
+    },
+    "minecraft:heavy_weighted_pressure_plate": {
+        id: "minecraft:heavy_weighted_pressure_plate",
+        name: "Heavy Weighted Pressure Plate",
+        hardness: 0.5,
+        blastResistance: 0.5,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["Heavy Weighted Pressure Plate"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Crafted from Iron Ingots"
+        },
+        description: "The Heavy Weighted Pressure Plate (Iron) is a redstone component designed to detect large groups of entities. Its signal strength increases by 1 for every 10 entities present (rounded up), requiring 141 or more entities to reach the maximum signal strength of 15. In Bedrock Edition, it is commonly used in high-capacity mob farms or security systems where a signal is only desired when many entities are present. Like other weighted plates, it can be activated by any entity type, including dropped items."
+    },
+    "minecraft:polished_blackstone_button": {
+        id: "minecraft:polished_blackstone_button",
+        name: "Polished Blackstone Button",
+        hardness: 0.5,
+        blastResistance: 0.5,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["Polished Blackstone Button"],
+        generation: {
+            dimension: "Nether",
+            yRange: "Bastion Remnants; Crafted from Polished Blackstone"
+        },
+        description: "The Polished Blackstone Button is a stone-type button introduced as part of the Nether Update. Like the standard stone button, it provides a redstone pulse lasting 10 ticks (1 second) when pressed. It can be activated by players and mobs but not by projectiles like arrows. Its dark, sleek appearance allows it to blend perfectly into blackstone structures or provide a high-contrast accent to lighter blocks. It is functionally identical to the stone button but offers a distinct aesthetic for Nether-themed builds."
     }
 };

--- a/scripts/data/search/block_index.js
+++ b/scripts/data/search/block_index.js
@@ -2924,5 +2924,40 @@ export const blockIndex = [
         category: "block",
         icon: "textures/blocks/fern",
         themeColor: "§2"
+    },
+    {
+        id: "minecraft:light_weighted_pressure_plate",
+        name: "Light Weighted Pressure Plate",
+        category: "block",
+        icon: "textures/blocks/light_weighted_pressure_plate",
+        themeColor: "§6"
+    },
+    {
+        id: "minecraft:heavy_weighted_pressure_plate",
+        name: "Heavy Weighted Pressure Plate",
+        category: "block",
+        icon: "textures/blocks/heavy_weighted_pressure_plate",
+        themeColor: "§7"
+    },
+    {
+        id: "minecraft:polished_blackstone_button",
+        name: "Polished Blackstone Button",
+        category: "block",
+        icon: "textures/blocks/polished_blackstone_button",
+        themeColor: "§8"
+    },
+    {
+        id: "minecraft:warped_door",
+        name: "Warped Door",
+        category: "block",
+        icon: "textures/items/door_warped",
+        themeColor: "§3"
+    },
+    {
+        id: "minecraft:crimson_door",
+        name: "Crimson Door",
+        category: "block",
+        icon: "textures/items/door_crimson",
+        themeColor: "§4"
     }
 ];


### PR DESCRIPTION
## Summary
Added 5 new unique block entries for Minecraft Bedrock Edition: Light Weighted Pressure Plate, Heavy Weighted Pressure Plate, Polished Blackstone Button, Warped Door, and Crimson Door.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [ ] Mob
- [x] Block
- [ ] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs