### PR TITLE
Add multiple block entries: Blue, Red, Black, Yellow, and Lime Concrete

### DIFF
--- a/scripts/data/providers/blocks/building/concrete.js
+++ b/scripts/data/providers/blocks/building/concrete.js
@@ -11,6 +11,111 @@
  */
 export const concreteBlocks = {
     // Add concrete and terracotta block entries here
+    "minecraft:blue_concrete": {
+        id: "minecraft:blue_concrete",
+        name: "Blue Concrete",
+        hardness: 1.8,
+        blastResistance: 1.8,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["Blue Concrete"],
+        generation: {
+            dimension: "None",
+            yRange: "Crafted only"
+        },
+        description: "Blue Concrete is a solid, vibrant building block known for its deep blue hue and smooth, matte texture. It is created by exposing Blue Concrete Powder to water, which hardens it instantly into this durable form. Unlike wool, Blue Concrete is non-flammable, making it an excellent choice for colorful structures that require fire safety. It is a favorite among builders for creating oceans, skies, or modern architectural accents due to its uniform color without distracting patterns."
+    },
+    "minecraft:red_concrete": {
+        id: "minecraft:red_concrete",
+        name: "Red Concrete",
+        hardness: 1.8,
+        blastResistance: 1.8,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["Red Concrete"],
+        generation: {
+            dimension: "None",
+            yRange: "Crafted only"
+        },
+        description: "Red Concrete is a bold, intensely colored building block that offers a smooth and clean finish for any construction. It is formed when Red Concrete Powder comes into contact with water, solidifying it. This block is highly valued in modern builds for its consistent, vibrant red color, which remains uniform across all sides. Its resistance to fire and decent blast resistance make it a more practical alternative to red wool or terracotta for many architectural projects."
+    },
+    "minecraft:black_concrete": {
+        id: "minecraft:black_concrete",
+        name: "Black Concrete",
+        hardness: 1.8,
+        blastResistance: 1.8,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["Black Concrete"],
+        generation: {
+            dimension: "None",
+            yRange: "Crafted only"
+        },
+        description: "Black Concrete is one of the darkest and most opaque blocks available in Minecraft, providing a sleek and modern aesthetic. It is produced by hydrating Black Concrete Powder with water. Because of its deep, uniform black color and lack of visible texture, it is often used for creating shadows, road surfaces, or high-contrast architectural designs. Unlike coal blocks or obsidian, it offers a perfectly smooth matte surface, making it indispensable for minimalist or futuristic builds."
+    },
+    "minecraft:yellow_concrete": {
+        id: "minecraft:yellow_concrete",
+        name: "Yellow Concrete",
+        hardness: 1.8,
+        blastResistance: 1.8,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["Yellow Concrete"],
+        generation: {
+            dimension: "None",
+            yRange: "Crafted only"
+        },
+        description: "Yellow Concrete is a bright and cheerful building block that provides a solid, sunny color with a smooth finish. It is created by allowing Yellow Concrete Powder to touch water, which triggers its transformation into a hardened state. This block is ideal for adding pops of color to a build or creating large-scale pixel art. Its non-flammable nature and clean look make it a superior choice over yellow wool for many permanent structures, offering a consistent hue that doesn't fade or vary."
+    },
+    "minecraft:lime_concrete": {
+        id: "minecraft:lime_concrete",
+        name: "Lime Concrete",
+        hardness: 1.8,
+        blastResistance: 1.8,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["Lime Concrete"],
+        generation: {
+            dimension: "None",
+            yRange: "Crafted only"
+        },
+        description: "Lime Concrete is a vivid, neon-green building block that offers a smooth and uniform surface. It is formed when Lime Concrete Powder is submerged in or touched by water. Its intense color is perfect for modern designs, vegetation-themed builds, or any project requiring a bright, eye-catching accent. As a non-flammable alternative to lime wool, it provides both safety and a more refined texture, making it a staple for creators focusing on clean lines and bold color palettes."
+    },
     "minecraft:white_concrete": {
         id: "minecraft:white_concrete",
         name: "White Concrete",

--- a/scripts/data/search/block_index.js
+++ b/scripts/data/search/block_index.js
@@ -2037,6 +2037,41 @@ export const blockIndex = [
         themeColor: "§f" // white
     },
     {
+        id: "minecraft:blue_concrete",
+        name: "Blue Concrete",
+        category: "block",
+        icon: "textures/blocks/concrete_blue",
+        themeColor: "§1" // blue
+    },
+    {
+        id: "minecraft:red_concrete",
+        name: "Red Concrete",
+        category: "block",
+        icon: "textures/blocks/concrete_red",
+        themeColor: "§c" // red
+    },
+    {
+        id: "minecraft:black_concrete",
+        name: "Black Concrete",
+        category: "block",
+        icon: "textures/blocks/concrete_black",
+        themeColor: "§0" // black
+    },
+    {
+        id: "minecraft:yellow_concrete",
+        name: "Yellow Concrete",
+        category: "block",
+        icon: "textures/blocks/concrete_yellow",
+        themeColor: "§e" // yellow
+    },
+    {
+        id: "minecraft:lime_concrete",
+        name: "Lime Concrete",
+        category: "block",
+        icon: "textures/blocks/concrete_lime",
+        themeColor: "§a" // lime
+    },
+    {
         id: "minecraft:white_wool",
         name: "White Wool",
         category: "block",


### PR DESCRIPTION
## Summary
Add 5 new concrete color block entries: Blue, Red, Black, Yellow, and Lime Concrete.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [ ] Mob
- [x] Block
- [ ] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs