### PR TITLE
Add multiple cherry wood block entries: Cherry Wood, Stripped Logs, Slabs, and Stairs

### DIFF
--- a/scripts/data/providers/blocks/building/slabs_stairs.js
+++ b/scripts/data/providers/blocks/building/slabs_stairs.js
@@ -533,5 +533,47 @@ export const slabsStairsBlocks = {
             yRange: "Crafted from Crimson Planks"
         },
         description: "Crimson Stairs are fire-resistant stairs crafted from crimson planks, a wood-type native to the Crimson Forest in the Nether. Unlike Overworld wooden stairs, they do not burn, making them ideal for construction in the Nether or near lava. They feature a deep maroon and red color scheme with an alien, fungal texture. They can be crafted using six crimson planks or via a stonecutter. Like all wooden stairs, they are best harvested with an axe. Their unique resistance to fire and distinctive color palette make them a favorite for builders seeking both safety and a dark, rustic aesthetic."
+    },
+    "minecraft:cherry_stairs": {
+        id: "minecraft:cherry_stairs",
+        name: "Cherry Stairs",
+        hardness: 2.0,
+        blastResistance: 3.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Cherry Stairs"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Crafted from Cherry Planks"
+        },
+        description: "Cherry Stairs are crafted from Cherry Planks and feature a light pink, aesthetic tone. Introduced in 1.20, they are popular for cute and colorful builds, offering a unique palette compared to other wood variants. Like all stairs, they are waterloggable and can be placed in multiple directions to create complex shapes like corners and eaves. They provide smooth elevation changes without jumping. Being a wood product, they are flammable and are best harvested using an axe."
+    },
+    "minecraft:cherry_slab": {
+        id: "minecraft:cherry_slab",
+        name: "Cherry Slab",
+        hardness: 2.0,
+        blastResistance: 3.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Cherry Slab"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Crafted from Cherry Planks"
+        },
+        description: "Cherry Slab is a half-block variant of Cherry planks, featuring the same distinctive pink texture. It provides a low-profile building option for floors, ceilings, and intricate architectural details. Crafted by placing three cherry planks horizontally or using a stonecutter, it is an essential part of the cherry wood family. Cherry slabs are flammable and can be combined into double slabs or placed in the top half of a block space. They offer a unique aesthetic that complements floral and colorful builds."
     }
 };

--- a/scripts/data/providers/blocks/natural/wood.js
+++ b/scripts/data/providers/blocks/natural/wood.js
@@ -640,5 +640,68 @@ export const woodBlocks = {
             yRange: "64 to 320"
         },
         description: "Acacia Leaves are found on the uniquely shaped, diagonal-growing acacia trees in savanna biomes. They have a distinct green color that complements the reddish-orange hue of acacia wood. Like other leaves, they are best harvested with shears or a silk touch tool. They contribute to the iconic silhouette of the savanna landscape. In Bedrock Edition, they serve as a versatile decoration block for players looking to recreate African-inspired landscapes or desert oases."
+    },
+    "minecraft:cherry_wood": {
+        id: "minecraft:cherry_wood",
+        name: "Cherry Wood",
+        hardness: 2.0,
+        blastResistance: 2.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Cherry Wood"],
+        generation: {
+            dimension: "None",
+            yRange: "Crafted from Cherry Logs"
+        },
+        description: "Cherry Wood is a block that has the bark texture of a cherry tree on all six sides. It is crafted by placing four cherry logs in a 2x2 grid. Unlike logs, which show rings on two ends, wood blocks provide a seamless bark appearance, making them ideal for building custom tree trunks, large branches, or decorative pillars. It features the signature dark purple bark of the cherry set and can be stripped with an axe to create stripped cherry wood."
+    },
+    "minecraft:stripped_cherry_log": {
+        id: "minecraft:stripped_cherry_log",
+        name: "Stripped Cherry Log",
+        hardness: 2.0,
+        blastResistance: 2.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Stripped Cherry Log"],
+        generation: {
+            dimension: "None",
+            yRange: "Axe on Cherry Log"
+        },
+        description: "Stripped Cherry Log is a variant of the cherry log created by using an axe on it. Stripping the bark reveals the beautiful, smooth pinkish interior of the wood. This version is often preferred by builders for its clean and uniform appearance, making it excellent for modern and detailed constructions. Introduced in the 1.20 Trails & Tales update, it can be crafted into cherry planks or used decoratively. Like all cherry wood blocks, it is flammable with a hardness and blast resistance of 2.0."
+    },
+    "minecraft:stripped_cherry_wood": {
+        id: "minecraft:stripped_cherry_wood",
+        name: "Stripped Cherry Wood",
+        hardness: 2.0,
+        blastResistance: 2.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Stripped Cherry Wood"],
+        generation: {
+            dimension: "None",
+            yRange: "Crafted from Stripped Cherry Logs"
+        },
+        description: "Stripped Cherry Wood is a decorative block with the stripped texture of cherry logs on all six faces. It provides a seamless, smooth pink surface, ideal for large wooden structures and artistic builds. It is crafted from stripped cherry logs or by stripping regular cherry wood with an axe. This block shares the fire-susceptible nature of overworld wood and is most effectively broken with an axe. Its uniform pink color provides a consistent aesthetic for large surfaces where bark would be distracting."
     }
 };

--- a/scripts/data/search/block_index.js
+++ b/scripts/data/search/block_index.js
@@ -3064,5 +3064,40 @@ export const blockIndex = [
         category: "block",
         icon: "textures/blocks/crimson_stairs",
         themeColor: "§4"
+    },
+    {
+        id: "minecraft:cherry_wood",
+        name: "Cherry Wood",
+        category: "block",
+        icon: "textures/blocks/cherry_wood",
+        themeColor: "§d"
+    },
+    {
+        id: "minecraft:stripped_cherry_log",
+        name: "Stripped Cherry Log",
+        category: "block",
+        icon: "textures/blocks/stripped_cherry_log",
+        themeColor: "§d"
+    },
+    {
+        id: "minecraft:stripped_cherry_wood",
+        name: "Stripped Cherry Wood",
+        category: "block",
+        icon: "textures/blocks/stripped_cherry_wood",
+        themeColor: "§d"
+    },
+    {
+        id: "minecraft:cherry_stairs",
+        name: "Cherry Stairs",
+        category: "block",
+        icon: "textures/blocks/cherry_stairs",
+        themeColor: "§d"
+    },
+    {
+        id: "minecraft:cherry_slab",
+        name: "Cherry Slab",
+        category: "block",
+        icon: "textures/blocks/cherry_slab",
+        themeColor: "§d"
     }
 ];


### PR DESCRIPTION
## Summary
Added 5 new unique cherry wood related block entries to the index.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [x] Block

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs

## Added Blocks
1. Cherry Wood
2. Stripped Cherry Log
3. Stripped Cherry Wood
4. Cherry Stairs
5. Cherry Slab