### PR TITLE
Add multiple block entries: Chiseled Copper variants, Powder Snow, and White Candle

### DIFF
--- a/scripts/data/providers/blocks/building/copper.js
+++ b/scripts/data/providers/blocks/building/copper.js
@@ -246,6 +246,69 @@ export const copperBlocks = {
         },
         description: "Chiseled Copper (1.21) is a decorative block with a unique geometric pattern. It is crafted by placing two cut copper slabs vertically or by using a stonecutter on cut copper. Like other copper blocks, it oxidizes over time through four distinct stages (unexposed to fully oxidized) unless waxed with a honeycomb. It generates naturally within Trial Chambers in various oxidation states. Builders use it for intricate architectural details, pillars, and accent walls due to its sophisticated carved appearance."
     },
+    "minecraft:exposed_chiseled_copper": {
+        id: "minecraft:exposed_chiseled_copper",
+        name: "Exposed Chiseled Copper",
+        hardness: 3.0,
+        blastResistance: 6.0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Stone",
+            silkTouch: false
+        },
+        drops: ["Exposed Chiseled Copper"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Trial Chambers"
+        },
+        description: "Exposed Chiseled Copper is the first oxidation stage of the chiseled copper block, featuring a slightly tarnished, brownish-orange appearance with hints of green. It retains the unique geometric pattern of the chiseled variant. Like other copper blocks, it naturally ages into weathered and oxidized states over time unless waxed with honeycomb. It is found within Trial Chambers or can be obtained by naturally weathering fresh chiseled copper. It can be scraped with an axe to return to its pristine state."
+    },
+    "minecraft:weathered_chiseled_copper": {
+        id: "minecraft:weathered_chiseled_copper",
+        name: "Weathered Chiseled Copper",
+        hardness: 3.0,
+        blastResistance: 6.0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Stone",
+            silkTouch: false
+        },
+        drops: ["Weathered Chiseled Copper"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Trial Chambers"
+        },
+        description: "Weathered Chiseled Copper represents the second stage of oxidation for the chiseled copper block, characterized by a distinct greenish-blue hue covering much of its carved surface. This decorative block maintains its intricate geometric designs while providing an aged, historical look. Found naturally in Trial Chambers, it can be waxed to preserve its current color or scraped with an axe to reveal the less-oxidized layers beneath. Its unique teal-orange mix is highly valued for adding detail to weathered structures."
+    },
+    "minecraft:oxidized_chiseled_copper": {
+        id: "minecraft:oxidized_chiseled_copper",
+        name: "Oxidized Chiseled Copper",
+        hardness: 3.0,
+        blastResistance: 6.0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Stone",
+            silkTouch: false
+        },
+        drops: ["Oxidized Chiseled Copper"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Trial Chambers"
+        },
+        description: "Oxidized Chiseled Copper is the final stage of oxidation for the chiseled copper block, boasting a full teal-green patina that covers its sophisticated geometric carvings. This block is perfect for ancient-themed builds, industrial ruins, or decorative accents that require a sense of deep history. It can be found within the corridors of Trial Chambers. Although fully oxidized, a player can still use an axe to scrape off the patina, reverting it stage by stage, or apply honeycomb to lock in its iconic green appearance."
+    },
     "minecraft:exposed_copper_grate": {
         id: "minecraft:exposed_copper_grate",
         name: "Exposed Copper Grate",

--- a/scripts/data/providers/blocks/functional/interactive.js
+++ b/scripts/data/providers/blocks/functional/interactive.js
@@ -516,6 +516,27 @@ export const interactiveBlocks = {
         },
         description: "A Candle is a light source block that can be placed in clusters of up to four. Each candle adds 3 to the light level, reaching a maximum of 12. Candles are crafted from string and honeycomb and can be dyed into 16 colors. They are unlit when placed and must be lit using flint and steel, fire charge, or any flaming projectile. Candles are waterloggable but cannot be lit while waterlogged. They can also be placed on cakes to create a candle cake."
     },
+    "minecraft:white_candle": {
+        id: "minecraft:white_candle",
+        name: "White Candle",
+        hardness: 0.1,
+        blastResistance: 0.1,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 3,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["White Candle"],
+        generation: {
+            dimension: "None",
+            yRange: "Crafted from a candle and White Dye"
+        },
+        description: "The White Candle is a clean, decorative light source that can be placed in groups of up to four on a single block. Each additional candle increases the light emitted by 3, up to a maximum of 12. It features a bright white wax appearance, making it ideal for modern, elegant, or snowy-themed builds. Like the undyed variant, it must be lit with flint and steel or a fire charge and can be placed on a cake to create a White Candle Cake. It is waterloggable but can only be lit when dry."
+    },
     "minecraft:structure_void": {
         id: "minecraft:structure_void",
         name: "Structure Void",

--- a/scripts/data/providers/blocks/natural/ice.js
+++ b/scripts/data/providers/blocks/natural/ice.js
@@ -91,5 +91,26 @@ export const iceBlocks = {
             yRange: "Snowy Biomes, Igloos"
         },
         description: "A Snow Block is a full-sized block crafted from four snowballs. It is primarily used for building and creating snow golems. Unlike snow layers, snow blocks are not affected by gravity and do not melt near light sources. They are easily broken with a shovel and are a common building material in cold biomes for creating igloos and snowy structures."
+    },
+    "minecraft:powder_snow": {
+        id: "minecraft:powder_snow",
+        name: "Powder Snow",
+        hardness: 0.25,
+        blastResistance: 0.25,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: [],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Snowy Slopes, Grove, Cauldrons"
+        },
+        description: "Powder Snow is a unique 'trap' block found in cold biomes like Snowy Slopes and Groves. Players and most mobs fall through it and eventually take freezing damage, indicated by a frosted screen overlay. Wearing leather boots allows players to walk on top of and even climb through powder snow without falling. It can also be collected from a cauldron that has filled up during snowfall. Unlike regular snow, it can only be obtained as an item using a bucket. It also extinguishes entities on fire that fall into it."
     }
 };

--- a/scripts/data/search/block_index.js
+++ b/scripts/data/search/block_index.js
@@ -511,6 +511,48 @@ export const blockIndex = [
         themeColor: "§6" // copper/orange
     },
     {
+        id: "minecraft:exposed_chiseled_copper",
+        name: "Exposed Chiseled Copper",
+        category: "block",
+        icon: "textures/blocks/exposed_chiseled_copper",
+        themeColor: "§6" // copper/orange
+    },
+    {
+        id: "minecraft:weathered_chiseled_copper",
+        name: "Weathered Chiseled Copper",
+        category: "block",
+        icon: "textures/blocks/weathered_chiseled_copper",
+        themeColor: "§3" // teal/cyan
+    },
+    {
+        id: "minecraft:oxidized_chiseled_copper",
+        name: "Oxidized Chiseled Copper",
+        category: "block",
+        icon: "textures/blocks/oxidized_chiseled_copper",
+        themeColor: "§b" // light aqua
+    },
+    {
+        id: "minecraft:exposed_chiseled_copper",
+        name: "Exposed Chiseled Copper",
+        category: "block",
+        icon: "textures/blocks/exposed_chiseled_copper",
+        themeColor: "§6" // copper/orange
+    },
+    {
+        id: "minecraft:weathered_chiseled_copper",
+        name: "Weathered Chiseled Copper",
+        category: "block",
+        icon: "textures/blocks/weathered_chiseled_copper",
+        themeColor: "§3" // teal/cyan
+    },
+    {
+        id: "minecraft:oxidized_chiseled_copper",
+        name: "Oxidized Chiseled Copper",
+        category: "block",
+        icon: "textures/blocks/oxidized_chiseled_copper",
+        themeColor: "§b" // light aqua
+    },
+    {
         id: "minecraft:pale_oak_log",
         name: "Pale Oak Log",
         category: "block",
@@ -2310,6 +2352,13 @@ export const blockIndex = [
         themeColor: "§e" // Yellow
     },
     {
+        id: "minecraft:white_candle",
+        name: "White Candle",
+        category: "block",
+        icon: "textures/items/candle_white",
+        themeColor: "§f" // white
+    },
+    {
         id: "minecraft:structure_void",
         name: "Structure Void",
         category: "block",
@@ -2853,6 +2902,20 @@ export const blockIndex = [
         name: "Snow Block",
         category: "block",
         icon: "textures/blocks/snow",
+        themeColor: "§f" // white
+    },
+    {
+        id: "minecraft:powder_snow",
+        name: "Powder Snow",
+        category: "block",
+        icon: "textures/blocks/powder_snow",
+        themeColor: "§f" // white
+    },
+    {
+        id: "minecraft:powder_snow",
+        name: "Powder Snow",
+        category: "block",
+        icon: "textures/blocks/powder_snow",
         themeColor: "§f" // white
     },
     {


### PR DESCRIPTION
## Summary
Adding 5 new unique block entries for Minecraft Bedrock: Exposed Chiseled Copper, Weathered Chiseled Copper, Oxidized Chiseled Copper, Powder Snow, and White Candle.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [x] Block

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs