### PR TITLE
Add multiple block entries: Dragon Egg, Cake, Quartz Stairs, Quartz Slab, and Cobblestone Wall

### DIFF
--- a/scripts/data/providers/blocks/building/slabs_stairs.js
+++ b/scripts/data/providers/blocks/building/slabs_stairs.js
@@ -617,5 +617,68 @@ export const slabsStairsBlocks = {
             yRange: "Crafted from Cherry Planks"
         },
         description: "Cherry Slab is a half-block variant of Cherry planks, featuring the same distinctive pink texture. It provides a low-profile building option for floors, ceilings, and intricate architectural details. Crafted by placing three cherry planks horizontally or using a stonecutter, it is an essential part of the cherry wood family. Cherry slabs are flammable and can be combined into double slabs or placed in the top half of a block space. They offer a unique aesthetic that complements floral and colorful builds."
+    },
+    "minecraft:quartz_stairs": {
+        id: "minecraft:quartz_stairs",
+        name: "Quartz Stairs",
+        hardness: 0.8,
+        blastResistance: 0.8,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["Quartz Stairs"],
+        generation: {
+            dimension: "None",
+            yRange: "Crafted/Stonecut"
+        },
+        description: "Quartz Stairs are decorative blocks crafted from blocks of quartz. They provide a smooth, bright white aesthetic that is popular for modern architecture, pillars, and classical-style buildings. Like other stairs, they are waterloggable and can be placed upside down or in corners to create complex shapes. They require a pickaxe to be harvested; otherwise, they drop nothing. They offer a more refined look compared to stone or wood stairs."
+    },
+    "minecraft:quartz_slab": {
+        id: "minecraft:quartz_slab",
+        name: "Quartz Slab",
+        hardness: 0.8,
+        blastResistance: 0.8,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["Quartz Slab"],
+        generation: {
+            dimension: "None",
+            yRange: "Crafted/Stonecut"
+        },
+        description: "Quartz Slab is a half-block variant of the block of quartz. It features the same clean, white texture and is used for detailed flooring, ceilings, and roofing. Slabs can be placed in the top or bottom half of a block space or combined into a double slab. Because it is stone-based, it is fire-resistant. It is an essential component for builders who want a bright, uniform appearance in their structures without the bulk of full blocks."
+    },
+    "minecraft:cobblestone_wall": {
+        id: "minecraft:cobblestone_wall",
+        name: "Cobblestone Wall",
+        hardness: 2.0,
+        blastResistance: 6.0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Pickaxe",
+            minTier: "Wood",
+            silkTouch: false
+        },
+        drops: ["Cobblestone Wall"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Villages, Pillager Outposts"
+        },
+        description: "Cobblestone Wall is a decorative and protective barrier block. It is 1.5 blocks high for entities, preventing them from jumping over it, while players can see over it easily. It connects automatically to adjacent blocks, solid objects, and other walls to form a continuous fence. It generates naturally in various structures like villages and outposts. It is highly durable and explosion-resistant, making it a reliable choice for fortifications and animal pens."
     }
 };

--- a/scripts/data/providers/blocks/dimension/end.js
+++ b/scripts/data/providers/blocks/dimension/end.js
@@ -157,6 +157,27 @@ export const endBlocks = {
         },
         description: "Chorus Plants are strange, branching tree-like structures native to the outer islands of the End dimension. They grow from a single Chorus Flower planted on End Stone. Breaking a lower section of the plant causes all sections above it to break as well, similar to sugar cane or cacti. When broken, they drop Chorus Fruit, which can be eaten to teleport the player to a nearby location or smelted into Popped Chorus Fruit for crafting Purpur blocks and End Rods. They provide a renewable resource for high-end building materials and survival mechanics in the End."
     },
+    "minecraft:dragon_egg": {
+        id: "minecraft:dragon_egg",
+        name: "Dragon Egg",
+        hardness: 3.0,
+        blastResistance: 9.0,
+        flammability: false,
+        gravityAffected: true,
+        transparent: true,
+        luminance: 1,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Dragon Egg"],
+        generation: {
+            dimension: "The End",
+            yRange: "Variable (On top of the Exit Portal)"
+        },
+        description: "The Dragon Egg is a rare decorative block and arguably the rarest item in Minecraft. It is dropped by the first Ender Dragon defeated in a world. In Bedrock Edition, a second egg can be obtained by defeating the dragon again. The egg is gravity-affected and teleports to a nearby location if a player attempts to mine it directly in Survival mode. To collect it, players must push it with a piston or cause it to fall onto a non-solid block like a torch or slab."
+    },
     "minecraft:end_portal_frame": {
         id: "minecraft:end_portal_frame",
         name: "End Portal Frame",

--- a/scripts/data/providers/blocks/functional/interactive.js
+++ b/scripts/data/providers/blocks/functional/interactive.js
@@ -516,6 +516,27 @@ export const interactiveBlocks = {
         },
         description: "A Candle is a light source block that can be placed in clusters of up to four. Each candle adds 3 to the light level, reaching a maximum of 12. Candles are crafted from string and honeycomb and can be dyed into 16 colors. They are unlit when placed and must be lit using flint and steel, fire charge, or any flaming projectile. Candles are waterloggable but cannot be lit while waterlogged. They can also be placed on cakes to create a candle cake."
     },
+    "minecraft:cake": {
+        id: "minecraft:cake",
+        name: "Cake",
+        hardness: 0.5,
+        blastResistance: 0.5,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: [],
+        generation: {
+            dimension: "None",
+            yRange: "Crafted only"
+        },
+        description: "Cake is a unique food block that can be placed on most solid blocks. Unlike other food, it cannot be eaten from the hotbar; it must be placed first. A single cake has seven slices, each restoring 2 hunger (1 drumstick) and 0.4 saturation. It is crafted using three buckets of milk, two sugar, one egg, and three wheat. Once a slice is eaten, it cannot be recovered, and if the block is broken, the cake is destroyed without dropping anything."
+    },
     "minecraft:structure_void": {
         id: "minecraft:structure_void",
         name: "Structure Void",

--- a/scripts/data/search/block_index.js
+++ b/scripts/data/search/block_index.js
@@ -3204,5 +3204,40 @@ export const blockIndex = [
         category: "block",
         icon: "textures/blocks/bamboo_fence",
         themeColor: "§e"
+    },
+    {
+        id: "minecraft:dragon_egg",
+        name: "Dragon Egg",
+        category: "block",
+        icon: "textures/blocks/dragon_egg",
+        themeColor: "§8"
+    },
+    {
+        id: "minecraft:cake",
+        name: "Cake",
+        category: "block",
+        icon: "textures/blocks/cake_top",
+        themeColor: "§f"
+    },
+    {
+        id: "minecraft:quartz_stairs",
+        name: "Quartz Stairs",
+        category: "block",
+        icon: "textures/blocks/quartz_stairs",
+        themeColor: "§f"
+    },
+    {
+        id: "minecraft:quartz_slab",
+        name: "Quartz Slab",
+        category: "block",
+        icon: "textures/blocks/quartz_slab",
+        themeColor: "§f"
+    },
+    {
+        id: "minecraft:cobblestone_wall",
+        name: "Cobblestone Wall",
+        category: "block",
+        icon: "textures/blocks/cobblestone_wall",
+        themeColor: "§7"
     }
 ];


### PR DESCRIPTION
## Summary
Added 5 new unique block entries for Minecraft Bedrock Edition: Dragon Egg, Cake, Quartz Stairs, Quartz Slab, and Cobblestone Wall.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [ ] Mob
- [x] Block
- [ ] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs