### PR TITLE
Add multiple block entries: Dragon Egg, End Portal, Nether Portal, Bubble Column, Jack o'Lantern

### DIFF
--- a/scripts/data/providers/blocks/decorative/lighting.js
+++ b/scripts/data/providers/blocks/decorative/lighting.js
@@ -219,5 +219,26 @@ export const lightingBlocks = {
             yRange: "Strongholds, Villages, Mineshafts, Ancient Cities"
         },
         description: "A Torch is a non-solid block that emits a light level of 14. It is one of the most common light sources in the game, essential for preventing hostile mob spawning and illuminating caves and structures. Crafted from a stick and coal or charcoal, torches can be placed on the top or sides of most solid blocks. They break if the block they are attached to is removed or if water flows into them. Torches are also used in crafting lanterns and jack o'lanterns."
+    },
+    "minecraft:lit_pumpkin": {
+        id: "minecraft:lit_pumpkin",
+        name: "Jack o'Lantern",
+        hardness: 1.0,
+        blastResistance: 1.0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: false,
+        luminance: 15,
+        mining: {
+            tool: "Axe",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Jack o'Lantern"],
+        generation: {
+            dimension: "None",
+            yRange: "Crafted only"
+        },
+        description: "A Jack o'Lantern is a luminous block crafted by combining a carved pumpkin and a torch. It emits a light level of 15, making it one of the brightest light sources in the game, equal to glowstone or sea lanterns. Unlike torches, Jack o'Lanterns can be placed underwater, making them excellent for illuminating ocean floors or underwater bases. They are also required for spawning snow golems and iron golems when used as the head."
     }
 };

--- a/scripts/data/providers/blocks/dimension/end.js
+++ b/scripts/data/providers/blocks/dimension/end.js
@@ -178,6 +178,48 @@ export const endBlocks = {
         },
         description: "An End Portal Frame is a block found in Strongholds that forms the End Portal. It is indestructible in survival mode. Players must place Eyes of Ender into the frames to activate the portal to the End. When 12 frames are placed in a 5x5 ring (corners omitted) and filled with eyes, the portal activates."
     },
+    "minecraft:end_portal": {
+        id: "minecraft:end_portal",
+        name: "End Portal",
+        hardness: -1,
+        blastResistance: 3600000,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 15,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: [],
+        generation: {
+            dimension: "The End",
+            yRange: "Inside End Portal Frame"
+        },
+        description: "The End Portal block is the shimmering, galaxy-textured surface that appears when an End Portal is activated. It is indestructible and cannot be obtained as an item. Stepping into this block instantly teleports the player between the Overworld and the End. It emits a maximum light level of 15 and has a unique visual effect that looks like a window into deep space."
+    },
+    "minecraft:dragon_egg": {
+        id: "minecraft:dragon_egg",
+        name: "Dragon Egg",
+        hardness: 3.0,
+        blastResistance: 9.0,
+        flammability: false,
+        gravityAffected: true,
+        transparent: true,
+        luminance: 1,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Dragon Egg"],
+        generation: {
+            dimension: "The End",
+            yRange: "Final boss pedestal"
+        },
+        description: "The Dragon Egg is a unique decorative block and the rarest item in Minecraft. It appears on top of the exit portal bedrock pedestal once the first Ender Dragon is defeated. When clicked or hit in survival, it teleports to a nearby location. To collect it, players must use a piston to push it or dig beneath it and place a torch so it falls onto the torch. It is primarily a trophy representing the player's victory over the final boss."
+    },
     "minecraft:purpur_slab": {
         id: "minecraft:purpur_slab",
         name: "Purpur Slab",

--- a/scripts/data/providers/blocks/dimension/nether.js
+++ b/scripts/data/providers/blocks/dimension/nether.js
@@ -767,5 +767,26 @@ export const netherBlocks = {
             yRange: "Crafted from Crimson Planks"
         },
         description: "The Crimson Door is a fire-resistant door made from crimson planks, native to the Crimson Forest biomes in the Nether. It shares the fireproof properties of all Nether wood types, ensuring it remains intact even when exposed to nearby lava or fire. Its deep maroon and red hues provide a dark, rustic aesthetic that complements netherrack and blackstone builds. Like other doors in Bedrock Edition, it can be used to block mob pathfinding and can be opened by hand or with redstone signals, all while resisting the Nether's heat."
+    },
+    "minecraft:portal": {
+        id: "minecraft:portal",
+        name: "Nether Portal",
+        hardness: -1,
+        blastResistance: 0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 11,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: [],
+        generation: {
+            dimension: "The Nether",
+            yRange: "Inside Obsidian frame"
+        },
+        description: "The Nether Portal block is the purple, translucent block that fills an activated obsidian portal frame. It emits a light level of 11 and produces portal particles. Standing inside this block for a few seconds teleports the player between the Overworld and the Nether. Though it has an indestructible hardness value, it is extremely fragile and will disappear if any part of the obsidian frame is broken, or if an explosion occurs nearby."
     }
 };

--- a/scripts/data/providers/blocks/natural/ice.js
+++ b/scripts/data/providers/blocks/natural/ice.js
@@ -91,5 +91,26 @@ export const iceBlocks = {
             yRange: "Snowy Biomes, Igloos"
         },
         description: "A Snow Block is a full-sized block crafted from four snowballs. It is primarily used for building and creating snow golems. Unlike snow layers, snow blocks are not affected by gravity and do not melt near light sources. They are easily broken with a shovel and are a common building material in cold biomes for creating igloos and snowy structures."
+    },
+    "minecraft:bubble_column": {
+        id: "minecraft:bubble_column",
+        name: "Bubble Column",
+        hardness: -1,
+        blastResistance: 0,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: [],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Underwater (above Magma/Soul Sand)"
+        },
+        description: "A Bubble Column is a vertical water current that provides air to players. It is created when a Magma Block (producing a downward whirlpool) or Soul Sand (producing upward bubbles) is placed underwater. These columns can be used to quickly transport players and items vertically. Upward columns push entities to the surface, while downward columns pull them to the bottom. They also prevent drowning by replenishing the air meter."
     }
 };

--- a/scripts/data/search/block_index.js
+++ b/scripts/data/search/block_index.js
@@ -322,6 +322,13 @@ export const blockIndex = [
         themeColor: "§b" // aqua
     },
     {
+        id: "minecraft:bubble_column",
+        name: "Bubble Column",
+        category: "block",
+        icon: "textures/blocks/magma",
+        themeColor: "§b" // aqua
+    },
+    {
         id: "minecraft:mud",
         name: "Mud",
         category: "block",
@@ -922,6 +929,13 @@ export const blockIndex = [
         category: "block",
         icon: "textures/blocks/ancient_debris_side",
         themeColor: "§8" // dark gray
+    },
+    {
+        id: "minecraft:portal",
+        name: "Nether Portal",
+        category: "block",
+        icon: "textures/blocks/portal",
+        themeColor: "§d" // light purple
     },
     {
         id: "minecraft:ender_chest",
@@ -1834,6 +1848,13 @@ export const blockIndex = [
         themeColor: "§6" // orange
     },
     {
+        id: "minecraft:lit_pumpkin",
+        name: "Jack o'Lantern",
+        category: "block",
+        icon: "textures/blocks/pumpkin_face_on",
+        themeColor: "§e" // yellow
+    },
+    {
         id: "minecraft:polished_tuff_wall",
         name: "Polished Tuff Wall",
         category: "block",
@@ -1930,6 +1951,20 @@ export const blockIndex = [
         category: "block",
         icon: "textures/blocks/end_portal_frame_top",
         themeColor: "§a" // green
+    },
+    {
+        id: "minecraft:end_portal",
+        name: "End Portal",
+        category: "block",
+        icon: "textures/blocks/end_portal",
+        themeColor: "§0" // black
+    },
+    {
+        id: "minecraft:dragon_egg",
+        name: "Dragon Egg",
+        category: "block",
+        icon: "textures/blocks/dragon_egg",
+        themeColor: "§0" // black
     },
     {
         id: "minecraft:hanging_sign",


### PR DESCRIPTION
## Summary
Added 5 new unique block entries for Minecraft Bedrock Edition to the encyclopedia index and providers.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [ ] Mob
- [x] Block
- [ ] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs (lit_pumpkin, portal, end_portal, bubble_column, dragon_egg)