### PR TITLE
Add block entries: Dragon Egg, Red Tulip, Cake, Bamboo

### DIFF
--- a/scripts/data/providers/blocks/dimension/end.js
+++ b/scripts/data/providers/blocks/dimension/end.js
@@ -303,5 +303,26 @@ export const endBlocks = {
             yRange: "75 (Main Island) / Various (Outer Islands)"
         },
         description: "The End Gateway is a small, indestructible portal block that facilitates travel between the main End island and outer islands. It generates when the Ender Dragon is defeated. Players can enter by throwing an ender pearl into the gap or by using a trapdoor to crawl through. It emits a powerful light level of 15 and features a unique end galaxy texture. This block is essential for exploring the vast outer reaches of the End where End Cities and Chorus Plants are found."
+    },
+    "minecraft:dragon_egg": {
+        id: "minecraft:dragon_egg",
+        name: "Dragon Egg",
+        hardness: 3.0,
+        blastResistance: 9.0,
+        flammability: false,
+        gravityAffected: true,
+        transparent: true,
+        luminance: 1,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Dragon Egg"],
+        generation: {
+            dimension: "The End",
+            yRange: "Top of the bedrock portal"
+        },
+        description: "The Dragon Egg is a rare trophy block and the final reward for defeating the Ender Dragon on the main island of the End. In Bedrock Edition, players can obtain up to two eggs by defeating the dragon twice. It is a gravity-affected block that teleports when a player attempts to mine it. To harvest it, players must push it with a piston or drop it onto a non-solid block like a torch. While primarily decorative, it remains one of the most prestigious items in the game, signifying the player's ultimate victory in the End dimension."
     }
 };

--- a/scripts/data/providers/blocks/functional/interactive.js
+++ b/scripts/data/providers/blocks/functional/interactive.js
@@ -704,5 +704,26 @@ export const interactiveBlocks = {
             yRange: "Crafted only"
         },
         description: "An Iron Trapdoor is a horizontal variant of the iron door, functioning as a one-block opening that only responds to redstone power. It cannot be toggled by player interaction, making it ideal for trap-based defenses, hidden entrances, or secure flooring. Like its vertical counterpart, it is fire-proof and explosion-resistant. Its sleek, metallic appearance also makes it a popular industrial-themed decoration for skylights, ventilation shafts, or futuristic flooring."
+    },
+    "minecraft:cake": {
+        id: "minecraft:cake",
+        name: "Cake",
+        hardness: 0.5,
+        blastResistance: 0.5,
+        flammability: false,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: [],
+        generation: {
+            dimension: "None",
+            yRange: "Crafted from 3 wheat, 2 sugar, 1 egg, and 3 milk buckets"
+        },
+        description: "Cake is a unique edible block that can be placed in the world. Unlike other food, it must be placed on a solid block before it can be eaten. It consists of seven slices, each restoring two hunger points and 0.4 saturation. Once placed, it cannot be picked back up and drops nothing when broken. In Bedrock Edition, it can be used as a redstone component, emitting a signal through a comparator based on the number of slices remaining. It can also be topped with a candle to create a Candle Cake, perfect for celebrations."
     }
 };

--- a/scripts/data/providers/blocks/natural/vegetation.js
+++ b/scripts/data/providers/blocks/natural/vegetation.js
@@ -1149,5 +1149,47 @@ export const vegetationBlocks = {
             yRange: "Taiga, Jungle, Flower Forest"
         },
         description: "Ferns are decorative vegetation blocks that add texture and detail to forest floors, especially in Taiga and Jungle biomes. They share properties with tall grass, appearing as small, bushy green plants. While they don't produce unique items, they can be harvested with shears for use in landscaping or placed in flower pots. Using bone meal on a fern will transform it into a Large Fern, which is two blocks tall. They are a staple for builders looking to create organic environments."
+    },
+    "minecraft:red_tulip": {
+        id: "minecraft:red_tulip",
+        name: "Red Tulip",
+        hardness: 0,
+        blastResistance: 0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "None",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Red Tulip"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Plains, Flower Forest biomes"
+        },
+        description: "The Red Tulip is a vibrant decorative flower found naturally in Plains and Flower Forest biomes. Like other tulips, it can be used to craft red dye or in suspicious stew recipes to provide the Weakness effect to the consumer. It can be planted in flower pots or directly on grass and dirt blocks to add a pop of color to gardens. While it has no health or defensive utility, its bright red petals make it a popular choice for aesthetic landscaping and floral arrangements in Bedrock Edition."
+    },
+    "minecraft:bamboo": {
+        id: "minecraft:bamboo",
+        name: "Bamboo",
+        hardness: 1.0,
+        blastResistance: 1.0,
+        flammability: true,
+        gravityAffected: false,
+        transparent: true,
+        luminance: 0,
+        mining: {
+            tool: "Sword",
+            minTier: "None",
+            silkTouch: false
+        },
+        drops: ["Bamboo"],
+        generation: {
+            dimension: "Overworld",
+            yRange: "Jungle biomes (especially Bamboo Jungle)"
+        },
+        description: "Bamboo is a versatile, fast-growing plant found in Jungle biomes. It can grow up to 12-16 blocks high and is the primary food source for pandas. When harvested, it can be used as fuel, providing one of the fastest ways to smelt items, or crafted into scaffolding, sticks, and bamboo wood sets. In Bedrock Edition, it has high growth rates and can be planted on many blocks including grass, dirt, and sand. Breaking the bottom-most stalk of a bamboo plant causes the entire tower to collapse, dropping all segments as items."
     }
 };

--- a/scripts/data/search/block_index.js
+++ b/scripts/data/search/block_index.js
@@ -3337,5 +3337,33 @@ export const blockIndex = [
         category: "block",
         icon: "textures/blocks/deepslate_bricks",
         themeColor: "§8"
+    },
+    {
+        id: "minecraft:dragon_egg",
+        name: "Dragon Egg",
+        category: "block",
+        icon: "textures/blocks/dragon_egg",
+        themeColor: "§5"
+    },
+    {
+        id: "minecraft:red_tulip",
+        name: "Red Tulip",
+        category: "block",
+        icon: "textures/blocks/flower_tulip_red",
+        themeColor: "§c"
+    },
+    {
+        id: "minecraft:cake",
+        name: "Cake",
+        category: "block",
+        icon: "textures/items/cake",
+        themeColor: "§f"
+    },
+    {
+        id: "minecraft:bamboo",
+        name: "Bamboo",
+        category: "block",
+        icon: "textures/items/bamboo",
+        themeColor: "§a"
     }
 ];


### PR DESCRIPTION
## Summary
Added 4 new unique block entries to the wiki: Dragon Egg, Red Tulip, Cake, and Bamboo. Each entry includes a detailed description, stats, and search index integration.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [x] Block

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs