### PR TITLE
Add Heavy Core, Sniffer Egg, and Woodland Explorer Map item entries

### DIFF
--- a/scripts/data/providers/items/materials/crafting.js
+++ b/scripts/data/providers/items/materials/crafting.js
@@ -293,6 +293,30 @@ export const craftingMaterials = {
         ],
         description: "Amethyst Shards are crystalline materials harvested from Amethyst Clusters found in underground Geodes. When mined with a pickaxe, a cluster drops 4 shards, increasing up to 16 with Fortune. They are renewable, as clusters regrow on immovable Budding Amethyst blocks. Shards can also be found in loot chests within Ancient Cities and Trial Chambers. Essential for crafting, they are used to create Spyglasses, Tinted Glass, Calibrated Sculk Sensors, and decorative Amethyst Blocks. Their vibrant purple color offers both functional utility and aesthetic appeal."
     },
+    "minecraft:heavy_core": {
+        id: "minecraft:heavy_core",
+        name: "Heavy Core",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Crafting the Mace",
+            secondaryUse: "Decorative block with high blast resistance"
+        },
+        crafting: {
+            recipeType: "Uncraftable",
+            ingredients: ["Rare drop from Ominous Vaults (Trial Chambers)"]
+        },
+        specialNotes: [
+            "Has a 2.2% chance to be ejected from an Ominous Vault",
+            "Essential component for crafting the Mace (Heavy Core + Breeze Rod)",
+            "Acts as a block that can be placed in the world",
+            "Requires a pickaxe to be mined successfully",
+            "Introduced in the 1.21 Tricky Trials update",
+            "Possesses a high blast resistance of 6.0"
+        ],
+        description: "The Heavy Core is a rare and dense block found exclusively within Ominous Vaults in Trial Chambers. It is a critical endgame material used to craft the Mace, a powerful weapon that deals increased damage based on fall distance. Aside from its utility in weaponry, the Heavy Core can be placed as a decorative block. Its high weight and resistance to explosions reflect its name, making it one of the most difficult and rewarding items to obtain in Trial Chambers."
+    },
     "minecraft:disc_fragment_5": {
         id: "minecraft:disc_fragment_5",
         name: "Disc Fragment 5",

--- a/scripts/data/providers/items/materials/drops.js
+++ b/scripts/data/providers/items/materials/drops.js
@@ -107,6 +107,30 @@ export const mobDrops = {
         ],
         description: "The Breeze Rod is a unique item dropped exclusively by Breezes in Trial Chambers. Similar to Blaze Rods, they serve as a fundamental crafting component for specialized items introduced in the 1.21 Tricky Trials update. A single Breeze Rod can be broken down into four Wind Charges or combined with a Heavy Core to create the powerful Mace weapon. Beyond crafting, Breeze Rods are essential for maintaining a Mace's durability at an anvil and can be used to duplicate the rare Flow Armor Trim smithing template."
     },
+    "minecraft:sniffer_egg": {
+        id: "minecraft:sniffer_egg",
+        name: "Sniffer Egg",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Hatching into a Snifflet",
+            secondaryUse: "Decorative block for ancient-themed builds"
+        },
+        crafting: {
+            recipeType: "Uncraftable",
+            ingredients: ["Obtained via archaeology in Warm Ocean Ruins", "Dropped when breeding two Sniffers"]
+        },
+        specialNotes: [
+            "Found by brushing Suspicious Sand in Warm Ocean Ruins (6.7% chance)",
+            "Obtained as an item when breeding two adult Sniffers",
+            "Must be placed on a block to hatch; takes approximately 20 minutes",
+            "Hatching time is halved (10 minutes) if placed on a Moss Block",
+            "Wobbles and develops cracks as it nears hatching",
+            "Cannot be broken by mobs jumping on it, unlike Turtle Eggs"
+        ],
+        description: "The Sniffer Egg is an ancient block that hatches into a Snifflet, the juvenile form of the Sniffer mob. These rare eggs can be recovered from the ocean floor by brushing suspicious sand in warm ocean ruins or produced by breeding two adult Sniffers. Once placed, the egg eventually hatches after 20 minutes of real-world time. Placing it on a moss block accelerates this process, causing it to hatch twice as fast. The egg's unique appearance and hatching mechanic make it a center-piece for ancient gardens and archaeological displays."
+    },
     "minecraft:armadillo_scute": {
         id: "minecraft:armadillo_scute",
         name: "Armadillo Scute",

--- a/scripts/data/providers/items/misc/other.js
+++ b/scripts/data/providers/items/misc/other.js
@@ -183,6 +183,30 @@ export const miscItems = {
         ],
         description: "The Trial Explorer Map is a specialized navigational tool used to uncover the location of Trial Chambers. These maps are not found in chests or crafted; instead, they must be purchased from a Journeyman-level Cartographer. The map reveals the surrounding terrain of a nearby Trial Chamber, marking its location with a small icon. This makes them indispensable for players looking to engage with the combat challenges and rewards of the chambers."
     },
+    "minecraft:woodland_explorer_map": {
+        id: "minecraft:woodland_explorer_map",
+        name: "Woodland Explorer Map",
+        maxStack: 1,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Locating Woodland Mansions",
+            secondaryUse: "Navigation in Roofed Forest biomes"
+        },
+        crafting: {
+            recipeType: "Trading",
+            ingredients: ["Journeyman Cartographer (Level 3)", "Emeralds", "Compass"]
+        },
+        specialNotes: [
+            "Purchased from Journeyman-level Cartographer villagers",
+            "Shows the terrain of the area containing the nearest Woodland Mansion",
+            "Includes a marker for the player's position relative to the mansion",
+            "The mansion is represented by a small house icon on the map",
+            "In Bedrock Edition, this is a type of Locator Map",
+            "Essential for finding the rare and dangerous Woodland Mansion structures"
+        ],
+        description: "The Woodland Explorer Map is a specialized locator map used to find Woodland Mansions, one of the rarest structures in Minecraft. Unlike standard maps, it comes pre-drawn with the terrain of the distant area surrounding a mansion. Players can obtain these maps by trading with a Journeyman-level Cartographer villager. The map features a unique icon for the mansion and a marker for the player's current location, helping them navigate across thousands of blocks to reach their destination and challenge the Illagers within."
+    },
     "minecraft:wolf_armor": {
         id: "minecraft:wolf_armor",
         name: "Wolf Armor",

--- a/scripts/data/search/item_index.js
+++ b/scripts/data/search/item_index.js
@@ -119,11 +119,25 @@ export const itemIndex = [
         themeColor: "§e"
     },
     {
+        id: "minecraft:woodland_explorer_map",
+        name: "Woodland Explorer Map",
+        category: "item",
+        icon: "textures/items/map_filled",
+        themeColor: "§e"
+    },
+    {
         id: "minecraft:mace",
         name: "Mace",
         category: "item",
         icon: "textures/items/mace",
         themeColor: "§6" // copper/brown
+    },
+    {
+        id: "minecraft:heavy_core",
+        name: "Heavy Core",
+        category: "item",
+        icon: "textures/items/heavy_core",
+        themeColor: "§d" // Purple
     },
     {
         id: "minecraft:ominous_bottle",
@@ -243,6 +257,13 @@ export const itemIndex = [
         category: "item",
         icon: "textures/items/spawn_egg_sniffer",
         themeColor: "§2" // dark green
+    },
+    {
+        id: "minecraft:sniffer_egg",
+        name: "Sniffer Egg",
+        category: "item",
+        icon: "textures/blocks/sniffer_egg",
+        themeColor: "§2"
     },
     {
         id: "minecraft:warden_spawn_egg",


### PR DESCRIPTION
## Summary
Added 3 new unique item entries: Heavy Core, Sniffer Egg, and Woodland Explorer Map.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [ ] Mob
- [ ] Block
- [x] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs