### PR TITLE
feat: Add Spear and Nautilus Armor (Mounts of Mayhem Update)

### DIFF
--- a/scripts/data/providers/items/misc/other.js
+++ b/scripts/data/providers/items/misc/other.js
@@ -762,6 +762,25 @@ export const miscItems = {
         ],
         description: "Diamond Horse Armor is the highest tier of protection available for horses in Minecraft Bedrock Edition. Unlike player armor, it cannot be crafted and must be discovered within chests in various structures throughout the world, such as Nether Fortresses, End Cities, and Bastion Remnants. When equipped on a tamed horse, it provides a significant boost to its survivability, granting 11 armor points to reduce incoming damage. This makes it an essential item for players who rely on horses for long-distance travel and combat."
     },
+    "minecraft:diamond_nautilus_armor": {
+        id: "minecraft:diamond_nautilus_armor",
+        name: "Diamond Nautilus Armor",
+        maxStack: 1,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Equipping on a tamed Nautilus mount for high protection",
+            secondaryUse: "Extending the Nautilus's survivability and adding toughness"
+        },
+        specialNotes: [
+            "Provides 11 armor points and 2 toughness when equipped on a Nautilus",
+            "Found in Shipwrecks, Ocean Ruins, and Buried Treasure chests",
+            "Indestructible equipment with no durability bar",
+            "Can be upgraded to Netherite Nautilus Armor using a Smithing Table",
+            "Introduced in the Mounts of Mayhem update (1.21.130+)"
+        ],
+        description: "Diamond Nautilus Armor is a high-tier protective equipment for the Nautilus mount, added in the Mounts of Mayhem update. Like horse armor, it does not have durability and cannot be crafted, requiring players to explore Shipwrecks, Ocean Ruins, and Buried Treasure to find it. It provides 11 armor points and 2 toughness, making the Nautilus significantly more resilient. It can also be upgraded to a Netherite version using a Netherite Upgrade Smithing Template for even greater protection."
+    },
     "minecraft:iron_horse_armor": {
         id: "minecraft:iron_horse_armor",
         name: "Iron Horse Armor",

--- a/scripts/data/providers/items/weapons/index.js
+++ b/scripts/data/providers/items/weapons/index.js
@@ -4,9 +4,11 @@
 import { swords } from './swords.js';
 import { rangedWeapons } from './ranged.js';
 import { projectiles } from './projectiles.js';
+import { spears } from './spears.js';
 
 export const weapons = {
     ...swords,
     ...rangedWeapons,
-    ...projectiles
+    ...projectiles,
+    ...spears
 };

--- a/scripts/data/providers/items/weapons/spears.js
+++ b/scripts/data/providers/items/weapons/spears.js
@@ -1,0 +1,56 @@
+// Pocket Wikipedia Foundation - Spear Weapons Data
+/** @type {Object.<string, import('../../item_types').ItemDetails>} */
+export const spears = {
+    "minecraft:diamond_spear": {
+        id: "minecraft:diamond_spear",
+        name: "Diamond Spear",
+        maxStack: 1,
+        durability: 1562,
+        enchantable: true,
+        usage: {
+            primaryUse: "Reach-based melee combat",
+            secondaryUse: "Jab and Charge attacks"
+        },
+        combat: {
+            attackDamage: 9,
+            attackSpeed: 0
+        },
+        crafting: {
+            recipeType: "Shaped",
+            ingredients: ["Diamond", "Stick x2"]
+        },
+        specialNotes: [
+            "Increased reach compared to swords",
+            "Deals 9 attack damage in Bedrock Edition",
+            "Can be enchanted with Lunge, Sharpness, and Looting",
+            "Introduced in the Mounts of Mayhem update (1.21.130+)"
+        ],
+        description: "The Diamond Spear is a powerful high-tier polearm added in the Mounts of Mayhem update. It offers superior reach compared to traditional swords, allowing players to keep foes at a distance. Crafted with a diamond and two sticks in a vertical pattern, it deals 9 damage per hit and can be upgraded to a Netherite version. Its unique lunge capability makes it a formidable weapon for both ground and mounted combat."
+    },
+    "minecraft:netherite_spear": {
+        id: "minecraft:netherite_spear",
+        name: "Netherite Spear",
+        maxStack: 1,
+        durability: 2031,
+        enchantable: true,
+        usage: {
+            primaryUse: "Elite reach-based combat",
+            secondaryUse: "Powerful mounted attacks"
+        },
+        combat: {
+            attackDamage: 10,
+            attackSpeed: 0
+        },
+        crafting: {
+            recipeType: "Smithing",
+            ingredients: ["Netherite Upgrade Smithing Template", "Diamond Spear", "Netherite Ingot"]
+        },
+        specialNotes: [
+            "Highest tier spear with 10 attack damage",
+            "Superior durability (2031 uses) and fire resistance",
+            "Enhanced reach for safe combat against dangerous mobs",
+            "Upgraded from a Diamond Spear at a Smithing Table"
+        ],
+        description: "The Netherite Spear represents the pinnacle of polearm weaponry in Minecraft. It combines the extreme durability and fire resistance of netherite with the extended reach of the spear. Dealing 10 damage in Bedrock Edition, it is an elite choice for late-game combat, especially when facing large groups or mounted enemies. Like other netherite gear, it does not burn in lava and must be upgraded from its diamond counterpart."
+    }
+};

--- a/scripts/data/search/item_index.js
+++ b/scripts/data/search/item_index.js
@@ -1512,6 +1512,13 @@ export const itemIndex = [
         themeColor: "§b"
     },
     {
+        id: "minecraft:diamond_nautilus_armor",
+        name: "Diamond Nautilus Armor",
+        category: "item",
+        icon: "textures/items/diamond_nautilus_armor",
+        themeColor: "§b"
+    },
+    {
         id: "minecraft:music_disc_otherside",
         name: "Music Disc (Otherside)",
         category: "item",
@@ -1649,6 +1656,20 @@ export const itemIndex = [
         name: "Netherite Sword",
         category: "item",
         icon: "textures/items/netherite_sword",
+        themeColor: "§8"
+    },
+    {
+        id: "minecraft:diamond_spear",
+        name: "Diamond Spear",
+        category: "item",
+        icon: "textures/items/diamond_spear",
+        themeColor: "§b"
+    },
+    {
+        id: "minecraft:netherite_spear",
+        name: "Netherite Spear",
+        category: "item",
+        icon: "textures/items/netherite_spear",
         themeColor: "§8"
     },
     {


### PR DESCRIPTION
This PR adds three new unique items from the December 2025 "Mounts of Mayhem" update (Game Drop 4):
1. **Diamond Spear**: A new tiered polearm weapon with increased reach and unique lunge capabilities.
2. **Netherite Spear**: The elite tier of the spear with maximum damage and netherite properties.
3. **Diamond Nautilus Armor**: High-tier indestructible equipment for the new Nautilus mount.

Changes:
- Added search index entries to `scripts/data/search/item_index.js`.
- Created `scripts/data/providers/items/weapons/spears.js` for spear data.
- Added `spears` to `scripts/data/providers/items/weapons/index.js`.
- Added Nautilus Armor data to `scripts/data/providers/items/misc/other.js`.

Verified the stats (damage, durability, recipes) match the latest Minecraft Bedrock 1.21.130 specifications.