### PR TITLE
Add Orange, Magenta, and Yellow Banner item entries

### DIFF
--- a/scripts/data/providers/items/misc/banner_items.js
+++ b/scripts/data/providers/items/misc/banner_items.js
@@ -128,5 +128,74 @@ export const bannerItems = {
             "Green dye is uniquely obtained by smelting Cactus in a furnace"
         ],
         description: "The Green Banner is a nature-inspired decorative item used to represent life, forests, and growth in Minecraft Bedrock Edition. It is crafted using six pieces of green wool and a single stick. Players often use it for camouflage in lush biomes or to mark hidden outposts. Like other banners, it can be elaborately decorated in a Loom and applied to shields. Since green dye requires smelting cactus, this banner represents a unique link to desert resources and farming."
+    },
+    "minecraft:orange_banner": {
+        id: "minecraft:orange_banner",
+        name: "Orange Banner",
+        maxStack: 16,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Decorative banner that can be placed on the ground or on walls",
+            secondaryUse: "Used in a Loom to create complex designs or applied to Shields for customization"
+        },
+        crafting: {
+            recipeType: "Shaped",
+            ingredients: ["6x Orange Wool", "1x Stick"]
+        },
+        specialNotes: [
+            "Crafted with 6 orange wool blocks in the top two rows and a stick in the bottom-middle slot",
+            "Orange wool can be obtained from orange sheep or by using orange dye from orange tulips or poppies",
+            "In Bedrock Edition, can be applied to a Shield in a crafting grid to transfer designs",
+            "Can be washed in a Cauldron to remove the top-most pattern layer",
+            "Has a maximum stack size of 16 items"
+        ],
+        description: "The Orange Banner is a bright, energetic decorative item used to display heraldry and mark territory in Minecraft Bedrock Edition. It is crafted by combining six pieces of orange wool with a single stick in a shaped recipe. Like other banners, it can be elaborately customized in a Loom using dyes and banner patterns to create unique designs. Since the 1.20 update, it can also be applied to Shields to provide a personalized defensive option. Its warm, vibrant color is perfect for desert builds, autumn-themed areas, or signaling danger and warmth."
+    },
+    "minecraft:magenta_banner": {
+        id: "minecraft:magenta_banner",
+        name: "Magenta Banner",
+        maxStack: 16,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Decorative banner that can be placed on the ground or on walls",
+            secondaryUse: "Used in a Loom to create complex designs or applied to Shields for customization"
+        },
+        crafting: {
+            recipeType: "Shaped",
+            ingredients: ["6x Magenta Wool", "1x Stick"]
+        },
+        specialNotes: [
+            "Crafted with 6 magenta wool blocks in the top two rows and a stick in the bottom-middle slot",
+            "Magenta dye is crafted by combining pink and purple dyes or from allium flowers",
+            "In Bedrock Edition, can be applied to a Shield in a crafting grid to transfer designs",
+            "Can be washed in a Cauldron to remove the top-most pattern layer",
+            "Has a maximum stack size of 16 items"
+        ],
+        description: "The Magenta Banner is a vibrant and unique decorative piece used for complex heraldry and base decoration in Minecraft Bedrock Edition. Crafted from six pieces of magenta wool and a stick, it offers a bold, purplish-pink hue that stands out in any environment. It serves as a base for intricate designs in a Loom and can be applied to shields for a personalized flair. Magenta dye is often obtained by combining pink and purple dyes, making this banner a symbol of sophisticated crafting. It is ideal for fantasy builds, magical-themed areas, or as a striking marker."
+    },
+    "minecraft:yellow_banner": {
+        id: "minecraft:yellow_banner",
+        name: "Yellow Banner",
+        maxStack: 16,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Decorative banner that can be placed on the ground or on walls",
+            secondaryUse: "Used in a Loom to create complex designs or applied to Shields for customization"
+        },
+        crafting: {
+            recipeType: "Shaped",
+            ingredients: ["6x Yellow Wool", "1x Stick"]
+        },
+        specialNotes: [
+            "Crafted with 6 yellow wool blocks in the top two rows and a stick in the bottom-middle slot",
+            "Yellow dye is obtained from dandelions or sunflowers",
+            "In Bedrock Edition, can be applied to a Shield in a crafting grid to transfer designs",
+            "Can be washed in a Cauldron to remove the top-most pattern layer",
+            "Has a maximum stack size of 16 items"
+        ],
+        description: "The Yellow Banner is a sun-colored decorative item used to brighten up builds and display player-created designs in Minecraft Bedrock Edition. It is crafted using six blocks of yellow wool and a single stick. This banner represents light and energy, making it a popular choice for marking settlements, shops, or farms. Beyond being a simple flag, it can be customized with various patterns in a Loom and applied to shields for personal expression. Its visibility from a distance makes it an excellent tool for navigation and signaling across the Overworld biomes."
     }
 };

--- a/scripts/data/search/item_index.js
+++ b/scripts/data/search/item_index.js
@@ -441,6 +441,27 @@ export const itemIndex = [
         themeColor: "§2" // green
     },
     {
+        id: "minecraft:orange_banner",
+        name: "Orange Banner",
+        category: "item",
+        icon: "textures/items/banner_orange",
+        themeColor: "§6" // orange
+    },
+    {
+        id: "minecraft:magenta_banner",
+        name: "Magenta Banner",
+        category: "item",
+        icon: "textures/items/banner_magenta",
+        themeColor: "§d" // magenta
+    },
+    {
+        id: "minecraft:yellow_banner",
+        name: "Yellow Banner",
+        category: "item",
+        icon: "textures/items/banner_yellow",
+        themeColor: "§e" // yellow
+    },
+    {
         id: "minecraft:flow_pottery_sherd",
         name: "Flow Pottery Sherd",
         category: "item",


### PR DESCRIPTION
## Summary
Adding 3 new unique banner item entries: Orange, Magenta, and Yellow Banners.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [ ] Mob
- [ ] Block
- [x] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs