### PR TITLE
Add Heavy Core, Iron Nautilus Armor, and Netherite Nautilus Armor item entries

### DIFF
--- a/scripts/data/providers/items/materials/crafting.js
+++ b/scripts/data/providers/items/materials/crafting.js
@@ -1589,5 +1589,28 @@ export const craftingMaterials = {
             "Part of the archaeology system introduced in the Trails & Tales update"
         ],
         description: "The Skull Pottery Sherd is an archaeological artifact found in Desert Temples by brushing Suspicious Sand. This pottery fragment features a clear skull design, representing danger or death. It is a tribute to the dangers of the desert and ancient temples. When used to craft a Decorated Pot, the Skull pattern creates a thematic decoration perfect for dungeons, graveyards, or any build that celebrates the macabre."
+    },
+    "minecraft:heavy_core": {
+        id: "minecraft:heavy_core",
+        name: "Heavy Core",
+        maxStack: 64,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Crafting the Mace weapon",
+            secondaryUse: "High-tier decorative block-item"
+        },
+        crafting: {
+            recipeType: "Uncraftable",
+            ingredients: ["Obtained from Ominous Vaults in Trial Chambers"]
+        },
+        specialNotes: [
+            "Rare reward from Ominous Vaults (8.3% chance in Bedrock Edition)",
+            "Essential for crafting the Mace (Heavy Core + Breeze Rod)",
+            "Blast resistance of 1200, making it highly resistant to explosions",
+            "Added in the 1.21 Tricky Trials update",
+            "Considered an 'Epic' rarity item with a purple name"
+        ],
+        description: "The Heavy Core is a rare and exceptionally dense material found exclusively as a reward from Ominous Vaults within Trial Chambers. Its primary purpose is to serve as the heavy head of a Mace, a unique weapon that increases in power the further a player falls before striking. Obtaining a Heavy Core requires players to brave the Ominous Trial challenges to get an Ominous Trial Key. Beyond its use in weaponry, it is one of the toughest items in the game, with a blast resistance and hardness that make it virtually indestructible."
     }
 };

--- a/scripts/data/providers/items/misc/other.js
+++ b/scripts/data/providers/items/misc/other.js
@@ -873,6 +873,52 @@ export const miscItems = {
         ],
         description: "Diamond Nautilus Armor is a high-tier protective equipment for the Nautilus mount, added in the Mounts of Mayhem update. Like horse armor, it does not have durability and cannot be crafted, requiring players to explore Shipwrecks, Ocean Ruins, and Buried Treasure to find it. It provides 11 armor points and 2 toughness, making the Nautilus significantly more resilient. It can also be upgraded to a Netherite version using a Netherite Upgrade Smithing Template for even greater protection."
     },
+    "minecraft:iron_nautilus_armor": {
+        id: "minecraft:iron_nautilus_armor",
+        name: "Iron Nautilus Armor",
+        maxStack: 1,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Equipping on a tamed Nautilus mount for defense",
+            secondaryUse: "Mid-tier protection for aquatic mounts"
+        },
+        crafting: {
+            recipeType: "Uncraftable",
+            ingredients: ["Found in Shipwrecks, Ocean Ruins, and Buried Treasure"]
+        },
+        specialNotes: [
+            "Provides 7 armor points (3.5 bars) when equipped on a Nautilus",
+            "Found in oceanic loot chests like Shipwrecks and Ocean Ruins",
+            "Cannot be crafted; must be discovered through exploration",
+            "Introduced in the Mounts of Mayhem update (1.21.130+)",
+            "Protects the Nautilus from Drowned and other hostile aquatic mobs"
+        ],
+        description: "Iron Nautilus Armor is a durable mid-tier equipment designed to protect the Nautilus mount. Introduced in the 1.21.130 'Mounts of Mayhem' update, it allows players to safeguard their aquatic steeds during undersea exploration. Like other mount armors, it lacks durability and cannot be crafted, requiring players to search for it in nautically-themed loot chests. Providing 7 armor points, it offers a solid balance of protection for players who have not yet secured diamond or netherite-tier nautical gear."
+    },
+    "minecraft:netherite_nautilus_armor": {
+        id: "minecraft:netherite_nautilus_armor",
+        name: "Netherite Nautilus Armor",
+        maxStack: 1,
+        durability: 0,
+        enchantable: false,
+        usage: {
+            primaryUse: "Maximum protection for a Nautilus mount",
+            secondaryUse: "Fire and lava resistance for mount equipment"
+        },
+        crafting: {
+            recipeType: "Smithing",
+            ingredients: ["Netherite Upgrade Smithing Template", "Diamond Nautilus Armor", "Netherite Ingot"]
+        },
+        specialNotes: [
+            "Provides 13 armor points and 3 toughness to the Nautilus",
+            "Elite protection level, outperforming diamond mount armor",
+            "Fire-resistant and floats on lava; will not burn if dropped",
+            "Must be upgraded from Diamond Nautilus Armor at a Smithing Table",
+            "Introduced in the Mounts of Mayhem update (1.21.130+)"
+        ],
+        description: "Netherite Nautilus Armor is the ultimate defensive equipment for the Nautilus mount in Minecraft Bedrock Edition. Added in the Mounts of Mayhem update, it is obtained by smithing Diamond Nautilus Armor with a Netherite Ingot and a Smithing Template. It provides a massive 13 armor points and 3 toughness, ensuring the Nautilus can withstand intense combat. Like all netherite equipment, it is resistant to fire and floats on lava, preventing the loss of this extremely valuable item in hazardous environments."
+    },
     "minecraft:iron_horse_armor": {
         id: "minecraft:iron_horse_armor",
         name: "Iron Horse Armor",

--- a/scripts/data/search/item_index.js
+++ b/scripts/data/search/item_index.js
@@ -147,6 +147,13 @@ export const itemIndex = [
         themeColor: "§6" // copper/brown
     },
     {
+        id: "minecraft:heavy_core",
+        name: "Heavy Core",
+        category: "item",
+        icon: "textures/items/heavy_core",
+        themeColor: "§5" // epic purple
+    },
+    {
         id: "minecraft:ominous_bottle",
         name: "Ominous Bottle",
         category: "item",
@@ -1769,6 +1776,20 @@ export const itemIndex = [
         category: "item",
         icon: "textures/items/diamond_nautilus_armor",
         themeColor: "§b"
+    },
+    {
+        id: "minecraft:iron_nautilus_armor",
+        name: "Iron Nautilus Armor",
+        category: "item",
+        icon: "textures/items/iron_nautilus_armor",
+        themeColor: "§f"
+    },
+    {
+        id: "minecraft:netherite_nautilus_armor",
+        name: "Netherite Nautilus Armor",
+        category: "item",
+        icon: "textures/items/netherite_nautilus_armor",
+        themeColor: "§8"
     },
     {
         id: "minecraft:music_disc_otherside",


### PR DESCRIPTION
## Summary
Added 3 new unique item entries for the 1.21 Tricky Trials and 1.21.130 Mounts of Mayhem updates.

## Entries Added
- [x] Search index entry added
- [x] Provider entry added
- [x] All required fields included

## Type
- [ ] Mob
- [ ] Block
- [x] Item

## Verification
- [x] I have verified the information is accurate
- [x] IDs match official Minecraft Bedrock Edition IDs